### PR TITLE
Reorganize DB configuration

### DIFF
--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
@@ -9,5 +9,5 @@ class ErrorController : ErrorController {
     val errorKey: String = "error"
 
     @RequestMapping("/**")
-    fun endpointNotFound(): Map<String, String> = mapOf(errorKey to "invalid endpoint")
+    fun endpointNotFound() = mapOf(errorKey to "invalid endpoint")
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
@@ -12,7 +12,7 @@ import pt.up.fe.ni.website.backend.service.EventService
 @RequestMapping("/events")
 class EventController(private val service: EventService) {
     @GetMapping
-    fun getAllEvents(): Collection<Event> = service.getAllEvents()
+    fun getAllEvents() = service.getAllEvents()
 
     @PostMapping("/new")
     fun createEvent(@RequestBody event: Event) = service.createEvent(event)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/IndexController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/IndexController.kt
@@ -6,5 +6,5 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class IndexController {
     @GetMapping("/")
-    fun healthCheck(): Map<String, String> = mapOf("online" to "true")
+    fun healthCheck() = mapOf("online" to "true")
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/EventService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/EventService.kt
@@ -6,7 +6,7 @@ import pt.up.fe.ni.website.backend.repository.EventRepository
 
 @Service
 class EventService(private val repository: EventRepository) {
-    fun getAllEvents(): Collection<Event> = repository.findAll().toList()
+    fun getAllEvents(): List<Event> = repository.findAll().toList()
 
     fun createEvent(event: Event) = repository.save(event)
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,14 +1,15 @@
-# H2
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2
-
 # Datasource
 spring.datasource.url=jdbc:h2:file:~/website-be-h2-db
 spring.datasource.username=h2dev
 spring.datasource.password=
-spring.datasource.driver-class-name=org.h2.Driver
+
+# Spring JPA
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
+
+# H2
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2
 
 # API Settings
 server.error.whitelabel.enabled=false
-spring.jpa.open-in-view=false


### PR DESCRIPTION
Closes #2 

After some discussion regarding which DB to use, we decided to stick with SQL. For development, we can keep using H2 and, for production, we only need to change the `spring.datasource.url` configuration in `application.properties`. This PR also removes the explicit driver from the config, since Spring Boot already infers it correctly based on the URL
