### PR TITLE
Validation and Error Handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.springframework.boot:spring-boot-starter-validation:2.7.3")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/BackendApplication.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/BackendApplication.kt
@@ -3,9 +3,11 @@ package pt.up.fe.ni.website.backend
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.web.servlet.config.annotation.EnableWebMvc
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableWebMvc
 class BackendApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/BackendApplication.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/BackendApplication.kt
@@ -3,11 +3,9 @@ package pt.up.fe.ni.website.backend
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
-import org.springframework.web.servlet.config.annotation.EnableWebMvc
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableWebMvc
 class BackendApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
@@ -1,14 +1,18 @@
 package pt.up.fe.ni.website.backend.controller
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import org.springframework.boot.web.servlet.error.ErrorController
 import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.validation.ObjectError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import org.springframework.web.servlet.NoHandlerFoundException
 
 data class SimpleError(
     val message: String,
@@ -18,10 +22,11 @@ data class SimpleError(
 
 data class CustomError(val errors: List<SimpleError>)
 
+@RestController
 @RestControllerAdvice
 class ErrorController : ErrorController {
 
-    @ExceptionHandler(NoHandlerFoundException::class)
+    @RequestMapping("/**")
     @ResponseStatus(HttpStatus.NOT_FOUND)
     fun endpointNotFound(): CustomError = wrapSimpleError("invalid endpoint")
 
@@ -42,6 +47,35 @@ class ErrorController : ErrorController {
         return CustomError(errors)
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun invalidRequestBody(e: HttpMessageNotReadableException): CustomError {
+        when (val cause = e.cause) {
+            is InvalidFormatException -> {
+                val type = cause.targetType.simpleName.lowercase()
+                return wrapSimpleError(
+                    "must be $type",
+                    value = cause.value
+                )
+            }
+
+            is MissingKotlinParameterException -> {
+                return wrapSimpleError(
+                    "required",
+                    param = cause.parameter.name
+                )
+            }
+        }
+
+        return wrapSimpleError(e.message ?: "invalid request body")
+    }
+
+    @ExceptionHandler(NoSuchElementException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun elementNotFound(e: NoSuchElementException): CustomError {
+        return wrapSimpleError(e.message ?: "element not found")
+    }
+
     @ExceptionHandler(Exception::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     fun unexpectedError(e: Exception): CustomError {
@@ -49,7 +83,7 @@ class ErrorController : ErrorController {
         return wrapSimpleError("unexpected error")
     }
 
-    fun wrapSimpleError(msg: String, param: String? = null) = CustomError(
-        mutableListOf(SimpleError(msg, param))
+    fun wrapSimpleError(msg: String, param: String? = null, value: Any? = null) = CustomError(
+        mutableListOf(SimpleError(msg, param, value))
     )
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
@@ -25,16 +25,22 @@ class ErrorController : ErrorController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun invalidArguments(e: MethodArgumentNotValidException): CustomError {
         val errors: MultipleErrors = mutableListOf()
-        e.bindingResult.allErrors.forEach {error: ObjectError ->
+        e.bindingResult.allErrors.forEach { error: ObjectError ->
             val fieldError = (error as FieldError)
-            errors.add(mapOf(
-                "param" to fieldError.field,
-                "message" to error.defaultMessage,
-                "value" to fieldError.rejectedValue
-            ))
+            errors.add(
+                mapOf(
+                    "param" to fieldError.field,
+                    "message" to error.defaultMessage,
+                    "value" to fieldError.rejectedValue
+                )
+            )
         }
         return mapOf(errorKey to errors)
     }
+
+    @ExceptionHandler(Exception::class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    fun unexpectedError(e: Exception): CustomError = wrapSimpleError(e.message ?: "unexpected error")
 
     fun wrapSimpleError(msg: String): CustomError = mapOf(
         errorKey to mutableListOf(mapOf("message" to msg))

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
@@ -1,13 +1,42 @@
 package pt.up.fe.ni.website.backend.controller
 
 import org.springframework.boot.web.servlet.error.ErrorController
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.http.HttpStatus
+import org.springframework.validation.FieldError
+import org.springframework.validation.ObjectError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.NoHandlerFoundException
 
-@RestController
+typealias MultipleErrors = MutableList<Map<String, Any?>>
+typealias CustomError = Map<String, MultipleErrors>
+
+@RestControllerAdvice
 class ErrorController : ErrorController {
-    val errorKey: String = "error"
+    val errorKey: String = "errors"
 
-    @RequestMapping("/**")
-    fun endpointNotFound() = mapOf(errorKey to "invalid endpoint")
+    @ExceptionHandler(NoHandlerFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun endpointNotFound(): CustomError = wrapSimpleError("invalid endpoint")
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun invalidArguments(e: MethodArgumentNotValidException): CustomError {
+        val errors: MultipleErrors = mutableListOf()
+        e.bindingResult.allErrors.forEach {error: ObjectError ->
+            val fieldError = (error as FieldError)
+            errors.add(mapOf(
+                "param" to fieldError.field,
+                "message" to error.defaultMessage,
+                "value" to fieldError.rejectedValue
+            ))
+        }
+        return mapOf(errorKey to errors)
+    }
+
+    fun wrapSimpleError(msg: String): CustomError = mapOf(
+        errorKey to mutableListOf(mapOf("message" to msg))
+    )
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
@@ -44,7 +44,10 @@ class ErrorController : ErrorController {
 
     @ExceptionHandler(Exception::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    fun unexpectedError(e: Exception): CustomError = wrapSimpleError(e.message ?: "unexpected error")
+    fun unexpectedError(e: Exception): CustomError {
+        System.err.println(e)
+        return wrapSimpleError("unexpected error")
+    }
 
     fun wrapSimpleError(msg: String, param: String? = null) = CustomError(
         mutableListOf(SimpleError(msg, param))

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
@@ -1,12 +1,9 @@
 package pt.up.fe.ni.website.backend.controller
 
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.service.EventService
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/events")
@@ -15,5 +12,5 @@ class EventController(private val service: EventService) {
     fun getAllEvents() = service.getAllEvents()
 
     @PostMapping("/new")
-    fun createEvent(@RequestBody event: Event) = service.createEvent(event)
+    fun createEvent(@Valid @RequestBody event: Event) = service.createEvent(event)
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
@@ -1,6 +1,10 @@
 package pt.up.fe.ni.website.backend.controller
 
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.service.EventService
 import javax.validation.Valid
@@ -12,5 +16,8 @@ class EventController(private val service: EventService) {
     fun getAllEvents() = service.getAllEvents()
 
     @PostMapping("/new")
-    fun createEvent(@Valid @RequestBody event: Event) = service.createEvent(event)
+    fun createEvent(
+        @Valid @RequestBody
+        event: Event
+    ) = service.createEvent(event)
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -19,8 +19,8 @@ class PostController(private val service: PostService) {
     @GetMapping
     fun getAllPosts(): Collection<Post> = service.getAllPosts()
 
-    @GetMapping("/{PostId}")
-    fun getPost(@PathVariable PostId: Long): Post = service.getPost(PostId)
+    @GetMapping("/{postId}")
+    fun getPost(@PathVariable postId: Long): Post = service.getPost(postId)
 
     @PostMapping("/new")
     fun createPost(
@@ -28,13 +28,13 @@ class PostController(private val service: PostService) {
         post: Post
     ) = service.createPost(post)
 
-    @PatchMapping("/{PostId}")
+    @PatchMapping("/{postId}")
     fun updatePost(
-        @PathVariable PostId: Long,
+        @PathVariable postId: Long,
         @Valid @RequestBody
         post: Post.PatchModel
-    ) = service.updatePost(PostId, post)
+    ) = service.updatePost(postId, post)
 
-    @DeleteMapping("/{PostId}")
-    fun deletePost(@PathVariable PostId: Long) = service.deletePost(PostId)
+    @DeleteMapping("/{postId}")
+    fun deletePost(@PathVariable postId: Long) = service.deletePost(postId)
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import pt.up.fe.ni.website.backend.model.Post
-import pt.up.fe.ni.website.backend.service.PostDto
 import pt.up.fe.ni.website.backend.service.PostService
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/posts")
@@ -23,10 +23,17 @@ class PostController(private val service: PostService) {
     fun getPost(@PathVariable PostId: Long): Post = service.getPost(PostId)
 
     @PostMapping("/new")
-    fun createPost(@RequestBody post: Post) = service.createPost(post)
+    fun createPost(
+        @Valid @RequestBody
+        post: Post
+    ) = service.createPost(post)
 
     @PatchMapping("/{PostId}")
-    fun updatePost(@PathVariable PostId: Long, @RequestBody post: PostDto) = service.updatePost(PostId, post)
+    fun updatePost(
+        @PathVariable PostId: Long,
+        @Valid @RequestBody
+        post: Post.PatchModel
+    ) = service.updatePost(PostId, post)
 
     @DeleteMapping("/{PostId}")
     fun deletePost(@PathVariable PostId: Long) = service.deletePost(PostId)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
@@ -6,15 +6,16 @@ import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.validation.constraints.Size
+import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
 
 @Entity
 class Event(
     @JsonProperty(required = true)
-    @field:Size(min = 2, max = 500)
+    @field:Size(min = Constants.Title.minSize, max = Constants.Title.maxSize)
     val title: String,
 
     @JsonProperty(required = true)
-    @field:Size(min = 10, max = 10000)
+    @field:Size(min = Constants.Description.minSize, max = Constants.Description.maxSize)
     val description: String,
 
     @JsonProperty(required = true)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
@@ -1,15 +1,21 @@
 package pt.up.fe.ni.website.backend.model
 
-import java.util.Date
+import java.util.*
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
+import javax.validation.constraints.Size
 
 @Entity
 class Event(
+    @field:Size(min = 2, max = 500)
     val title: String,
+
+    @field:Size(min = 10, max = 10000)
     val description: String,
+
     val date: Date,
+
     @Id @GeneratedValue
     val id: Long? = null
 )

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
@@ -1,6 +1,7 @@
 package pt.up.fe.ni.website.backend.model
 
-import java.util.*
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.Date
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
@@ -8,12 +9,15 @@ import javax.validation.constraints.Size
 
 @Entity
 class Event(
+    @JsonProperty(required = true)
     @field:Size(min = 2, max = 500)
     val title: String,
 
+    @JsonProperty(required = true)
     @field:Size(min = 10, max = 10000)
     val description: String,
 
+    @JsonProperty(required = true)
     val date: Date,
 
     @Id @GeneratedValue

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
@@ -1,5 +1,6 @@
 package pt.up.fe.ni.website.backend.model
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -8,14 +9,41 @@ import javax.persistence.Entity
 import javax.persistence.EntityListeners
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
+import javax.validation.constraints.NotEmpty
+import javax.validation.constraints.Size
 
 @Entity
 @EntityListeners(AuditingEntityListener::class)
 class Post(
+    @JsonProperty(required = true)
+    @field:Size(min = 2, max = 500)
     var title: String,
+
+    @JsonProperty(required = true)
+    @field:Size(min = 10, message = "size must be greater than 10")
     var body: String,
+
+    @field:NotEmpty
     var thumbnailPath: String,
-    @CreatedDate var publishDate: Date? = null,
-    @LastModifiedDate var lastUpdatedAt: Date? = null,
-    @Id @GeneratedValue val id: Long? = null
-)
+
+    @CreatedDate
+    var publishDate: Date? = null,
+
+    @LastModifiedDate
+    var lastUpdatedAt: Date? = null,
+
+    @Id @GeneratedValue
+    val id: Long? = null
+) {
+    data class PatchModel(
+        @field:Size(min = 2, max = 500)
+        var title: String?,
+
+        @field:Size(min = 10, message = "size must be greater than 10")
+        var body: String?,
+
+        // Using @Size because @NotEmpty doesn't validate nulls
+        @field:Size(min = 1, message = "must not be empty")
+        var thumbnailPath: String?
+    )
+}

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
@@ -11,16 +11,17 @@ import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.Size
+import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
 
 @Entity
 @EntityListeners(AuditingEntityListener::class)
 class Post(
     @JsonProperty(required = true)
-    @field:Size(min = 2, max = 500)
+    @field:Size(min = Constants.Title.minSize, max = Constants.Title.maxSize)
     var title: String,
 
     @JsonProperty(required = true)
-    @field:Size(min = 10, message = "size must be greater than 10")
+    @field:Size(min = Constants.Body.minSize, message = "size must be greater than ${Constants.Body.minSize}")
     var body: String,
 
     @field:NotEmpty
@@ -36,10 +37,10 @@ class Post(
     val id: Long? = null
 ) {
     data class PatchModel(
-        @field:Size(min = 2, max = 500)
+        @field:Size(min = Constants.Title.minSize, max = Constants.Title.maxSize)
         var title: String?,
 
-        @field:Size(min = 10, message = "size must be greater than 10")
+        @field:Size(min = Constants.Body.minSize, message = "size must be greater than ${Constants.Body.minSize}")
         var body: String?,
 
         // Using @Size because @NotEmpty doesn't validate nulls

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/EventConstants.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/EventConstants.kt
@@ -1,0 +1,13 @@
+package pt.up.fe.ni.website.backend.model.constants
+
+object EventConstants {
+    object Title {
+        const val minSize = 2
+        const val maxSize = 500
+    }
+
+    object Description {
+        const val minSize = 10
+        const val maxSize = 10000
+    }
+}

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/PostConstants.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/PostConstants.kt
@@ -1,0 +1,12 @@
+package pt.up.fe.ni.website.backend.model.constants
+
+object PostConstants {
+    object Title {
+        const val minSize = 2
+        const val maxSize = 500
+    }
+
+    object Body {
+        const val minSize = 10
+    }
+}

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -9,14 +9,14 @@ import pt.up.fe.ni.website.backend.repository.PostRepository
 class PostService(private val repository: PostRepository) {
     fun getAllPosts(): List<Post> = repository.findAll().toList()
 
-    fun getPost(PostId: Long): Post =
-        repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("post not found with id $PostId")
+    fun getPost(postId: Long): Post =
+        repository.findByIdOrNull(postId) ?: throw NoSuchElementException("post not found with id $postId")
 
     fun createPost(post: Post): Post = repository.save(post)
 
-    fun updatePost(PostId: Long, post: Post.PatchModel): Post {
+    fun updatePost(postId: Long, post: Post.PatchModel): Post {
         val targetPost =
-            repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("post not found with id $PostId")
+            repository.findByIdOrNull(postId) ?: throw NoSuchElementException("post not found with id $postId")
         targetPost.title = post.title ?: targetPost.title
         targetPost.body = post.body ?: targetPost.body
         targetPost.thumbnailPath = post.thumbnailPath ?: targetPost.thumbnailPath
@@ -24,9 +24,9 @@ class PostService(private val repository: PostRepository) {
         return repository.save(targetPost)
     }
 
-    fun deletePost(PostId: Long): Map<String, String> {
-        repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("post not found with id $PostId")
-        repository.deleteById(PostId)
+    fun deletePost(postId: Long): Map<String, String> {
+        repository.findByIdOrNull(postId) ?: throw NoSuchElementException("post not found with id $postId")
+        repository.deleteById(postId)
 
         return mapOf()
     }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -5,12 +5,6 @@ import org.springframework.stereotype.Service
 import pt.up.fe.ni.website.backend.model.Post
 import pt.up.fe.ni.website.backend.repository.PostRepository
 
-class PostDto {
-    var title: String? = null
-    var body: String? = null
-    var thumbnailPath: String? = null
-}
-
 @Service
 class PostService(private val repository: PostRepository) {
     fun getAllPosts(): List<Post> = repository.findAll().toList()
@@ -18,9 +12,9 @@ class PostService(private val repository: PostRepository) {
     fun getPost(PostId: Long): Post =
         repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("Post Not Found")
 
-    fun createPost(post: Post) = repository.save(post)
+    fun createPost(post: Post): Post = repository.save(post)
 
-    fun updatePost(PostId: Long, post: PostDto): Post {
+    fun updatePost(PostId: Long, post: Post.PatchModel): Post {
         val targetPost = repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("Post Not Found")
         targetPost.title = post.title ?: targetPost.title
         targetPost.body = post.body ?: targetPost.body

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -10,12 +10,13 @@ class PostService(private val repository: PostRepository) {
     fun getAllPosts(): List<Post> = repository.findAll().toList()
 
     fun getPost(PostId: Long): Post =
-        repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("Post Not Found")
+        repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("post not found with id $PostId")
 
     fun createPost(post: Post): Post = repository.save(post)
 
     fun updatePost(PostId: Long, post: Post.PatchModel): Post {
-        val targetPost = repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("Post Not Found")
+        val targetPost =
+            repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("post not found with id $PostId")
         targetPost.title = post.title ?: targetPost.title
         targetPost.body = post.body ?: targetPost.body
         targetPost.thumbnailPath = post.thumbnailPath ?: targetPost.thumbnailPath
@@ -24,7 +25,7 @@ class PostService(private val repository: PostRepository) {
     }
 
     fun deletePost(PostId: Long): Map<String, String> {
-        repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("Post Not Found")
+        repository.findByIdOrNull(PostId) ?: throw NoSuchElementException("post not found with id $PostId")
         repository.deleteById(PostId)
 
         return mapOf()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,4 @@ server.error.whitelabel.enabled=false
 
 # Jackson
 spring.jackson.default-property-inclusion=non_null
+spring.jackson.deserialization.fail-on-null-creator-properties=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,4 +13,6 @@ spring.h2.console.path=/h2
 
 # API Settings
 server.error.whitelabel.enabled=false
-spring.mvc.throw-exception-if-no-handler-found=true
+
+# Jackson
+spring.jackson.default-property-inclusion=non_null

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,4 @@ spring.h2.console.path=/h2
 
 # API Settings
 server.error.whitelabel.enabled=false
+spring.mvc.throw-exception-if-no-handler-found=true


### PR DESCRIPTION
closes #7 
closes #15 

This PR adds simple validation for the `events` endpoints, serving as example for the other resources. It also introduces error handling with a consistent format of error messages, including validation and other types of errors.

Errors around Jackson and its binding errors are not working as great as I'd want them to. Since I spent way too long hitting my head with this problem, I created #27 and left that problem for later.

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [x] Contains enough appropriate tests
-   [x] Behavior is as expected
-   [x] Clean, well structured code
