### PR TITLE
Feature/post slug

### DIFF
--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -33,6 +33,6 @@ class PostController(private val service: PostService) {
     @DeleteMapping("/{postId:[0-9]+}")
     fun deletePost(@PathVariable postId: Long) = service.deletePostById(postId)
 
-    @GetMapping("/{postSlang:[a-z-]+}")
-    fun getPost(@PathVariable postSlang: String) = service.getPostBySlang(postSlang)
+    @GetMapping("/{postSlug:[a-z-]+}")
+    fun getPost(@PathVariable postSlug: String) = service.getPostBySlug(postSlug)
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -18,21 +18,21 @@ class PostController(private val service: PostService) {
     @GetMapping
     fun getAllPosts() = service.getAllPosts()
 
-    @GetMapping("/{postId:[0-9]+}")
+    @GetMapping("/{postId:\\d+}")
     fun getPost(@PathVariable postId: Long) = service.getPostById(postId)
 
     @PostMapping("/new")
     fun createPost(@RequestBody dto: PostDto) = service.createPost(dto)
 
-    @PutMapping("/{postId:[0-9]+}")
+    @PutMapping("/{postId:\\d+}")
     fun updatePost(
         @PathVariable postId: Long,
         @RequestBody dto: PostDto
     ) = service.updatePostById(postId, dto)
 
-    @DeleteMapping("/{postId:[0-9]+}")
+    @DeleteMapping("/{postId:\\d+}")
     fun deletePost(@PathVariable postId: Long) = service.deletePostById(postId)
 
-    @GetMapping("/{postSlug:[a-z-]+}")
+    @GetMapping("/{postSlug}**")
     fun getPost(@PathVariable postSlug: String) = service.getPostBySlug(postSlug)
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -24,13 +24,13 @@ class PostController(private val service: PostService) {
     @PostMapping("/new")
     fun createPost(@RequestBody dto: PostDto) = service.createPost(dto)
 
-    @PutMapping("/{postId:\\d+}")
+    @PutMapping("/{postId}")
     fun updatePost(
         @PathVariable postId: Long,
         @RequestBody dto: PostDto
     ) = service.updatePostById(postId, dto)
 
-    @DeleteMapping("/{postId:\\d+}")
+    @DeleteMapping("/{postId}")
     fun deletePost(@PathVariable postId: Long) = service.deletePostById(postId)
 
     @GetMapping("/{postSlug}**")

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -18,18 +18,21 @@ class PostController(private val service: PostService) {
     @GetMapping
     fun getAllPosts() = service.getAllPosts()
 
-    @GetMapping("/{postId}")
+    @GetMapping("/{postId:[0-9]+}")
     fun getPost(@PathVariable postId: Long) = service.getPostById(postId)
 
     @PostMapping("/new")
     fun createPost(@RequestBody dto: PostDto) = service.createPost(dto)
 
-    @PutMapping("/{postId}")
+    @PutMapping("/{postId:[0-9]+}")
     fun updatePost(
         @PathVariable postId: Long,
         @RequestBody dto: PostDto
     ) = service.updatePostById(postId, dto)
 
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/{postId:[0-9]+}")
     fun deletePost(@PathVariable postId: Long) = service.deletePostById(postId)
+
+    @GetMapping("/{postSlang:[a-z-]+}")
+    fun getPost(@PathVariable postSlang: String) = service.getPostBySlang(postSlang)
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -21,6 +21,9 @@ class PostController(private val service: PostService) {
     @GetMapping("/{postId:\\d+}")
     fun getPost(@PathVariable postId: Long) = service.getPostById(postId)
 
+    @GetMapping("/{postSlug}**")
+    fun getPost(@PathVariable postSlug: String) = service.getPostBySlug(postSlug)
+
     @PostMapping("/new")
     fun createPost(@RequestBody dto: PostDto) = service.createPost(dto)
 
@@ -32,7 +35,4 @@ class PostController(private val service: PostService) {
 
     @DeleteMapping("/{postId}")
     fun deletePost(@PathVariable postId: Long) = service.deletePostById(postId)
-
-    @GetMapping("/{postSlug}**")
-    fun getPost(@PathVariable postSlug: String) = service.getPostBySlug(postSlug)
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/PostDto.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/PostDto.kt
@@ -5,5 +5,6 @@ import pt.up.fe.ni.website.backend.model.Post
 class PostDto(
     val title: String,
     val body: String,
-    val thumbnailPath: String
+    val thumbnailPath: String,
+    val slang: String?
 ) : EntityDto<Post>()

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/PostDto.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/PostDto.kt
@@ -6,5 +6,5 @@ class PostDto(
     val title: String,
     val body: String,
     val thumbnailPath: String,
-    val slang: String?
+    val slug: String?
 ) : EntityDto<Post>()

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
@@ -13,6 +13,7 @@ import org.hibernate.validator.constraints.URL
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import pt.up.fe.ni.website.backend.annotations.validation.NullOrNotBlank
 import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
 
@@ -43,7 +44,7 @@ class Post(
     val id: Long? = null,
 
     @Column(unique = true)
-    @JsonProperty(required = false)
-    @field:Size(min = Constants.Slang.minSize, max = Constants.Slang.maxSize)
-    val slang: String? = null
+    @field:Size(min = Constants.Slug.minSize, max = Constants.Slug.maxSize)
+    @NullOrNotBlank
+    val slug: String? = null
 )

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
@@ -13,7 +13,6 @@ import org.hibernate.validator.constraints.URL
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import pt.up.fe.ni.website.backend.annotations.validation.NullOrNotBlank
 import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
 
@@ -45,6 +44,5 @@ class Post(
 
     @Column(unique = true)
     @field:Size(min = Constants.Slug.minSize, max = Constants.Slug.maxSize)
-    @NullOrNotBlank
     val slug: String? = null
 )

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
@@ -2,6 +2,7 @@ package pt.up.fe.ni.website.backend.model
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.GeneratedValue
@@ -39,5 +40,10 @@ class Post(
     var lastUpdatedAt: Date? = null,
 
     @Id @GeneratedValue
-    val id: Long? = null
+    val id: Long? = null,
+
+    @Column(unique = true)
+    @JsonProperty(required = false)
+    @field:Size(min = Constants.Slang.minSize, max = Constants.Slang.maxSize)
+    val slang: String? = null
 )

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/PostConstants.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/PostConstants.kt
@@ -9,4 +9,9 @@ object PostConstants {
     object Body {
         const val minSize = 10
     }
+
+    object Slang {
+        const val minSize = 2
+        const val maxSize = 500
+    }
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/PostConstants.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/constants/PostConstants.kt
@@ -10,7 +10,7 @@ object PostConstants {
         const val minSize = 10
     }
 
-    object Slang {
+    object Slug {
         const val minSize = 2
         const val maxSize = 500
     }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/repository/PostRepository.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/repository/PostRepository.kt
@@ -3,4 +3,6 @@ package pt.up.fe.ni.website.backend.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import pt.up.fe.ni.website.backend.model.Post
 
-interface PostRepository : JpaRepository<Post, Long>
+interface PostRepository : JpaRepository<Post, Long> {
+    fun findBySlang(slang: String): Post?
+}

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/repository/PostRepository.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/repository/PostRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import pt.up.fe.ni.website.backend.model.Post
 
 interface PostRepository : JpaRepository<Post, Long> {
-    fun findBySlang(slang: String): Post?
+    fun findBySlug(slug: String): Post?
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/repository/PostRepository.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/repository/PostRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import pt.up.fe.ni.website.backend.model.Post
 
 interface PostRepository : JpaRepository<Post, Long> {
-    fun findBySlug(slug: String): Post?
+    fun findBySlug(slug: String?): Post?
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/ErrorMessages.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/ErrorMessages.kt
@@ -1,6 +1,8 @@
 package pt.up.fe.ni.website.backend.service
 
 object ErrorMessages {
+    const val slugAlreadyExists = "slug already exists"
+
     const val emailAlreadyExists = "email already exists"
 
     const val invalidCredentials = "invalid credentials"

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/ErrorMessages.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/ErrorMessages.kt
@@ -11,6 +11,8 @@ object ErrorMessages {
 
     fun postNotFound(postId: Long): String = "post not found with id $postId"
 
+    fun postNotFound(postSlang: String): String = "post not found with slang $postSlang"
+
     fun projectNotFound(id: Long): String = "project not found with id $id"
 
     fun accountNotFound(id: Long): String = "account not found with id $id"

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/ErrorMessages.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/ErrorMessages.kt
@@ -11,7 +11,7 @@ object ErrorMessages {
 
     fun postNotFound(postId: Long): String = "post not found with id $postId"
 
-    fun postNotFound(postSlang: String): String = "post not found with slang $postSlang"
+    fun postNotFound(postSlug: String): String = "post not found with slug $postSlug"
 
     fun projectNotFound(id: Long): String = "project not found with id $id"
 

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -26,7 +26,8 @@ class PostService(private val repository: PostRepository) {
         val post = getPostById(postId)
 
         repository.findBySlug(dto.slug)?.let {
-            throw IllegalArgumentException(ErrorMessages.slugAlreadyExists)
+            if(it.id != post.id) // TEST
+                throw IllegalArgumentException(ErrorMessages.slugAlreadyExists)
         }
 
         val newPost = dto.update(post)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -29,4 +29,7 @@ class PostService(private val repository: PostRepository) {
         repository.deleteById(postId)
         return mapOf()
     }
+
+    fun getPostBySlang(postSlang: String): Post =
+        repository.findBySlang(postSlang) ?: throw NoSuchElementException(ErrorMessages.postNotFound(postSlang))
 }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -14,6 +14,10 @@ class PostService(private val repository: PostRepository) {
         repository.findByIdOrNull(postId) ?: throw NoSuchElementException(ErrorMessages.postNotFound(postId))
 
     fun createPost(dto: PostDto): Post {
+        repository.findBySlug(dto.slug)?.let {
+            throw IllegalArgumentException(ErrorMessages.slugAlreadyExists)
+        }
+
         val post = dto.create()
         return repository.save(post)
     }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -26,8 +26,7 @@ class PostService(private val repository: PostRepository) {
         val post = getPostById(postId)
 
         repository.findBySlug(dto.slug)?.let {
-            if(it.id != post.id) // TEST
-                throw IllegalArgumentException(ErrorMessages.slugAlreadyExists)
+            if (it.id != post.id) throw IllegalArgumentException(ErrorMessages.slugAlreadyExists)
         }
 
         val newPost = dto.update(post)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -23,9 +23,14 @@ class PostService(private val repository: PostRepository) {
     }
 
     fun updatePostById(postId: Long, dto: PostDto): Post {
-        val project = getPostById(postId)
-        val newProject = dto.update(project)
-        return repository.save(newProject)
+        val post = getPostById(postId)
+
+        repository.findBySlug(dto.slug)?.let {
+            throw IllegalArgumentException(ErrorMessages.slugAlreadyExists)
+        }
+
+        val newPost = dto.update(post)
+        return repository.save(newPost)
     }
 
     fun deletePostById(postId: Long): Map<String, String> {

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/PostService.kt
@@ -30,6 +30,6 @@ class PostService(private val repository: PostRepository) {
         return mapOf()
     }
 
-    fun getPostBySlang(postSlang: String): Post =
-        repository.findBySlang(postSlang) ?: throw NoSuchElementException(ErrorMessages.postNotFound(postSlang))
+    fun getPostBySlug(postSlug: String): Post =
+        repository.findBySlug(postSlug) ?: throw NoSuchElementException(ErrorMessages.postNotFound(postSlug))
 }

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
@@ -253,6 +253,21 @@ internal class PostControllerTest @Autowired constructor(
                 @Test
                 fun `should not be empty`() = validationTester.isNotEmpty()
             }
+
+            @Nested
+            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
+            @DisplayName("slug")
+            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+            inner class SlugValidation {
+                @BeforeAll
+                fun setParam() {
+                    validationTester.param = "slug"
+                }
+
+                @Test
+                @DisplayName("size should be between ${Constants.Slug.minSize} and ${Constants.Slug.maxSize}()")
+                fun size() = validationTester.hasSizeBetween(Constants.Slug.minSize, Constants.Slug.maxSize)
+            }
         }
     }
 
@@ -491,6 +506,21 @@ internal class PostControllerTest @Autowired constructor(
 
                 @Test
                 fun `should not be empty`() = validationTester.isNotEmpty()
+            }
+
+            @Nested
+            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
+            @DisplayName("slug")
+            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+            inner class SlugValidation {
+                @BeforeAll
+                fun setParam() {
+                    validationTester.param = "slug"
+                }
+
+                @Test
+                @DisplayName("size should be between ${Constants.Slug.minSize} and ${Constants.Slug.maxSize}()")
+                fun size() = validationTester.hasSizeBetween(Constants.Slug.minSize, Constants.Slug.maxSize)
             }
         }
     }

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
@@ -41,7 +41,7 @@ internal class PostControllerTest @Autowired constructor(
         "New test released",
         "this is a test post",
         "https://thumbnails/test.png",
-        slang = "new-test-released"
+        slug = "new-test-released"
     )
 
     @Nested
@@ -107,7 +107,7 @@ internal class PostControllerTest @Autowired constructor(
     }
 
     @Nested
-    @DisplayName("GET /posts/{postSlang}")
+    @DisplayName("GET /posts/{postSlug}")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetPostBySlang {
         @BeforeAll
@@ -117,7 +117,7 @@ internal class PostControllerTest @Autowired constructor(
 
         @Test
         fun `should return the post`() {
-            mockMvc.get("/posts/${testPost.slang}")
+            mockMvc.get("/posts/${testPost.slug}")
                 .andExpect {
                     status { isOk() }
                     content { contentType(MediaType.APPLICATION_JSON) }
@@ -135,7 +135,7 @@ internal class PostControllerTest @Autowired constructor(
                 status { isNotFound() }
                 content { contentType(MediaType.APPLICATION_JSON) }
                 jsonPath("$.errors.length()") { value(1) }
-                jsonPath("$.errors[0].message") { value("post not found with slang fail-slang") }
+                jsonPath("$.errors[0].message") { value("post not found with slug fail-slang") }
             }
         }
     }

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
@@ -308,12 +308,14 @@ internal class PostControllerTest @Autowired constructor(
         @BeforeAll
         fun addPost() {
             repository.save(testPost)
-            repository.save(Post(
-                "New test released",
-                "this is a test post",
-                "https://thumbnails/test.png",
-                slug = "duplicated-slug"
-            ))
+            repository.save(
+                Post(
+                    "New test released",
+                    "this is a test post",
+                    "https://thumbnails/test.png",
+                    slug = "duplicated-slug"
+                )
+            )
         }
 
         private var updatedSlug = testPost.slug


### PR DESCRIPTION
Closes #25

This pull request aims to give the option of using a slug instead of an id to request a post from the backend.

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
