### PR TITLE
Register for a future event

### DIFF
--- a/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/EventDto.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/EventDto.kt
@@ -6,6 +6,6 @@ import java.util.Date
 class EventDto(
     val title: String,
     val description: String,
-    val registerUrl: String,
+    val registerUrl: String?,
     val date: Date
 ) : EntityDto<Event>()

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/EventDto.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/EventDto.kt
@@ -6,5 +6,6 @@ import java.util.Date
 class EventDto(
     val title: String,
     val description: String,
+    val registerUrl: String,
     val date: Date
 ) : EntityDto<Event>()

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
@@ -3,6 +3,7 @@ package pt.up.fe.ni.website.backend.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.persistence.Entity
 import org.hibernate.validator.constraints.URL
+import pt.up.fe.ni.website.backend.annotations.validation.NullOrNotBlank
 import java.util.Date
 
 @Entity
@@ -10,9 +11,9 @@ class Event(
     title: String,
     description: String,
 
-    @JsonProperty(required = true)
+    @field:NullOrNotBlank
     @field:URL
-    var registerUrl: String,
+    var registerUrl: String? = null,
 
     @JsonProperty(required = true)
     val date: Date,

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
@@ -2,12 +2,17 @@ package pt.up.fe.ni.website.backend.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.persistence.Entity
+import org.hibernate.validator.constraints.URL
 import java.util.Date
 
 @Entity
 class Event(
     title: String,
     description: String,
+
+    @JsonProperty(required = true)
+    @field:URL
+    var registerUrl: String,
 
     @JsonProperty(required = true)
     val date: Date,

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -48,7 +48,7 @@ internal class EventControllerTest @Autowired constructor(
             Event(
                 "Bad event",
                 "This event was a failure",
-                "https://docs.google.com/forms",
+                null,
                 TestUtils.createDate(2021, Calendar.OCTOBER, 27)
             )
         )
@@ -101,7 +101,6 @@ internal class EventControllerTest @Autowired constructor(
                 requiredFields = mapOf(
                     "title" to testEvent.title,
                     "description" to testEvent.description,
-                    "registerUrl" to testEvent.registerUrl,
                     "date" to testEvent.date
                 )
             )
@@ -151,7 +150,7 @@ internal class EventControllerTest @Autowired constructor(
                 }
 
                 @Test
-                fun `should be required`() = validationTester.isRequired()
+                fun `should be null or not blank`() = validationTester.isNullOrNotBlank()
 
                 @Test
                 fun `should be a URL`() = validationTester.isUrl()

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -35,6 +35,7 @@ internal class EventControllerTest @Autowired constructor(
     val testEvent = Event(
         "Great event",
         "This was a nice and iconic event",
+        "https://docs.google.com/forms",
         TestUtils.createDate(2022, Calendar.JULY, 28)
     )
 
@@ -47,6 +48,7 @@ internal class EventControllerTest @Autowired constructor(
             Event(
                 "Bad event",
                 "This event was a failure",
+                "https://docs.google.com/forms",
                 TestUtils.createDate(2021, Calendar.OCTOBER, 27)
             )
         )
@@ -81,6 +83,7 @@ internal class EventControllerTest @Autowired constructor(
                     content { contentType(MediaType.APPLICATION_JSON) }
                     jsonPath("$.title") { value(testEvent.title) }
                     jsonPath("$.description") { value(testEvent.description) }
+                    jsonPath("$.registerUrl") { value(testEvent.registerUrl) }
                     jsonPath("$.date") { value(containsString("28-07-2022")) }
                 }
         }
@@ -98,6 +101,7 @@ internal class EventControllerTest @Autowired constructor(
                 requiredFields = mapOf(
                     "title" to testEvent.title,
                     "description" to testEvent.description,
+                    "registerUrl" to testEvent.registerUrl,
                     "date" to testEvent.date
                 )
             )
@@ -135,6 +139,22 @@ internal class EventControllerTest @Autowired constructor(
                 @DisplayName("size should be between ${Constants.Description.minSize} and ${Constants.Description.maxSize}()")
                 fun size() =
                     validationTester.hasSizeBetween(Constants.Description.minSize, Constants.Description.maxSize)
+            }
+
+            @Nested
+            @DisplayName("registerUrl")
+            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+            inner class RegisterUrlValidation {
+                @BeforeAll
+                fun setParam() {
+                    validationTester.param = "registerUrl"
+                }
+
+                @Test
+                fun `should be required`() = validationTester.isRequired()
+
+                @Test
+                fun `should be a URL`() = validationTester.isUrl()
             }
 
             @Nested


### PR DESCRIPTION
Closes #62  

Adds a `registerUrl` parameter to `Event` which should be a link to a registration platform (most likely google forms).  
Tests were updated accordingly.  

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
