### PR TITLE
Adds custom test annotations for simplicity and consistency

### DIFF
--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -3,11 +3,8 @@ package pt.up.fe.ni.website.backend.controller
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -19,6 +16,8 @@ import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
+import pt.up.fe.ni.website.backend.utils.annotations.EndpointTest
+import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
 import java.util.Calendar
 import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
@@ -43,9 +42,8 @@ class AccountControllerTest @Autowired constructor(
         )
     )
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /accounts")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetAllAccounts {
         private val testAccounts = listOf(
             testAccount,
@@ -78,9 +76,8 @@ class AccountControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /accounts/{id}")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetAccount {
         @BeforeAll
         fun addAccount() {
@@ -117,7 +114,7 @@ class AccountControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("POST /accounts/new")
     inner class CreateAccount {
         @AfterEach
@@ -146,7 +143,7 @@ class AccountControllerTest @Autowired constructor(
             }
         }
 
-        @Nested
+        @NestedTest
         @DisplayName("Input Validation")
         inner class InputValidation {
             private val validationTester = ValidationTester(
@@ -164,9 +161,8 @@ class AccountControllerTest @Autowired constructor(
                 )
             )
 
-            @Nested
+            @NestedTest
             @DisplayName("name")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class NameValidation {
                 @BeforeAll
                 fun setParam() {
@@ -181,9 +177,8 @@ class AccountControllerTest @Autowired constructor(
                 fun size() = validationTester.hasSizeBetween(Constants.Name.minSize, Constants.Name.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("email")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class EmailValidation {
                 @BeforeAll
                 fun setParam() {
@@ -200,9 +195,8 @@ class AccountControllerTest @Autowired constructor(
                 fun `should be a valid email`() = validationTester.isEmail()
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("password")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class PasswordValidation {
                 @BeforeAll
                 fun setParam() {
@@ -217,9 +211,8 @@ class AccountControllerTest @Autowired constructor(
                 fun size() = validationTester.hasSizeBetween(Constants.Password.minSize, Constants.Password.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("bio")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class BioValidation {
                 @BeforeAll
                 fun setParam() {
@@ -232,9 +225,8 @@ class AccountControllerTest @Autowired constructor(
                     validationTester.hasSizeBetween(Constants.Bio.minSize, Constants.Bio.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("birthDate")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class BirthDateValidation {
                 @BeforeAll
                 fun setParam() {
@@ -248,9 +240,8 @@ class AccountControllerTest @Autowired constructor(
                 fun `should be in the past`() = validationTester.isPastDate()
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("photoPath")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class PhotoPathValidation {
                 @BeforeAll
                 fun setParam() {
@@ -264,9 +255,8 @@ class AccountControllerTest @Autowired constructor(
                 fun `should be URL`() = validationTester.isUrl()
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("linkedin")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class LinkedinValidation {
                 @BeforeAll
                 fun setParam() {
@@ -280,9 +270,8 @@ class AccountControllerTest @Autowired constructor(
                 fun `should be URL`() = validationTester.isUrl()
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("github")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class GithubValidation {
                 @BeforeAll
                 fun setParam() {
@@ -296,7 +285,7 @@ class AccountControllerTest @Autowired constructor(
                 fun `should be URL`() = validationTester.isUrl()
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("websites")
             inner class WebsitesValidation {
                 private val validationTester = ValidationTester(
@@ -318,16 +307,19 @@ class AccountControllerTest @Autowired constructor(
                     )
                 )
 
-                @Nested
+                @NestedTest
                 @DisplayName("url")
                 inner class UrlValidation {
-                    @BeforeEach
+                    @BeforeAll
                     fun setParam() {
                         validationTester.param = "url"
                     }
 
                     @Test
-                    fun `should be required`() = validationTester.isRequired()
+                    fun `should be required`() {
+                        validationTester.parameterName = "url"
+                        validationTester.isRequired()
+                    }
 
                     @Test
                     fun `should not be empty`() {
@@ -342,10 +334,10 @@ class AccountControllerTest @Autowired constructor(
                     }
                 }
 
-                @Nested
+                @NestedTest
                 @DisplayName("iconPath")
                 inner class IconPathValidation {
-                    @BeforeEach
+                    @BeforeAll
                     fun setParam() {
                         validationTester.param = "iconPath"
                     }

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -9,11 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -22,14 +18,12 @@ import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
+import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import java.util.Calendar
 import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureTestDatabase
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ControllerTest
 class AccountControllerTest @Autowired constructor(
     val mockMvc: MockMvc,
     val objectMapper: ObjectMapper,

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -20,6 +18,7 @@ import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
+import pt.up.fe.ni.website.backend.utils.annotations.EndpointTest
 import java.util.Calendar
 
 @ControllerTest
@@ -46,9 +45,8 @@ class AuthControllerTest @Autowired constructor(
         )
     )
 
-    @Nested
+    @EndpointTest
     @DisplayName("POST /auth/new")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetNewToken {
         @BeforeAll
         fun setup() {
@@ -95,9 +93,8 @@ class AuthControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("POST /auth/refresh")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class RefreshToken {
         @BeforeAll
         fun setup() {
@@ -133,9 +130,8 @@ class AuthControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /auth/check")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class CheckToken {
         @BeforeAll
         fun setup() {

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
@@ -8,12 +8,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -23,12 +19,10 @@ import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
+import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import java.util.Calendar
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureTestDatabase
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ControllerTest
 class AuthControllerTest @Autowired constructor(
     val repository: AccountRepository,
     val mockMvc: MockMvc,

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -17,6 +15,8 @@ import pt.up.fe.ni.website.backend.repository.EventRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
+import pt.up.fe.ni.website.backend.utils.annotations.EndpointTest
+import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
 import java.util.Calendar
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants as Constants
 
@@ -33,9 +33,8 @@ internal class EventControllerTest @Autowired constructor(
         TestUtils.createDate(2022, Calendar.JULY, 28)
     )
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /events")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetAllEvents {
         private val testEvents = listOf(
             testEvent,
@@ -63,7 +62,7 @@ internal class EventControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("POST /events/new")
     inner class CreateEvent {
         @Test
@@ -82,7 +81,7 @@ internal class EventControllerTest @Autowired constructor(
                 }
         }
 
-        @Nested
+        @NestedTest
         @DisplayName("Input Validation")
         inner class InputValidation {
             private val validationTester = ValidationTester(
@@ -99,9 +98,8 @@ internal class EventControllerTest @Autowired constructor(
                 )
             )
 
-            @Nested
+            @NestedTest
             @DisplayName("title")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class TitleValidation {
                 @BeforeAll
                 fun setParam() {
@@ -116,9 +114,8 @@ internal class EventControllerTest @Autowired constructor(
                 fun size() = validationTester.hasSizeBetween(Constants.Title.minSize, Constants.Title.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("description")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class DescriptionValidation {
                 @BeforeAll
                 fun setParam() {
@@ -134,9 +131,8 @@ internal class EventControllerTest @Autowired constructor(
                     validationTester.hasSizeBetween(Constants.Description.minSize, Constants.Description.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("registerUrl")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class RegisterUrlValidation {
                 @BeforeAll
                 fun setParam() {
@@ -150,9 +146,8 @@ internal class EventControllerTest @Autowired constructor(
                 fun `should be a URL`() = validationTester.isUrl()
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("date")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class DateValidation {
                 @BeforeAll
                 fun setParam() {

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -8,11 +8,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -20,13 +16,11 @@ import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.repository.EventRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
+import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import java.util.Calendar
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants as Constants
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureTestDatabase
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ControllerTest
 internal class EventControllerTest @Autowired constructor(
     val mockMvc: MockMvc,
     val objectMapper: ObjectMapper,

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
@@ -6,12 +6,9 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.test.context.NestedTestConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
@@ -21,6 +18,8 @@ import pt.up.fe.ni.website.backend.model.Post
 import pt.up.fe.ni.website.backend.repository.PostRepository
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
+import pt.up.fe.ni.website.backend.utils.annotations.EndpointTest
+import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
 import java.text.SimpleDateFormat
 import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
@@ -38,9 +37,8 @@ internal class PostControllerTest @Autowired constructor(
         slug = "new-test-released"
     )
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /posts")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetAllPosts {
         private val testPosts = listOf(
             testPost,
@@ -66,9 +64,8 @@ internal class PostControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /posts/{postId}")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetPostById {
         @BeforeAll
         fun addPost() {
@@ -100,10 +97,9 @@ internal class PostControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /posts/{postSlug}")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    inner class GetPostBySlug {
+    inner class GetPostBySlang {
         @BeforeAll
         fun addPost() {
             repository.save(testPost)
@@ -135,7 +131,7 @@ internal class PostControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("POST /posts/new")
     inner class CreatePost {
         @BeforeEach
@@ -179,9 +175,8 @@ internal class PostControllerTest @Autowired constructor(
             }
         }
 
-        @Nested
+        @NestedTest
         @DisplayName("Input Validation")
-        @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
         inner class InputValidation {
             private val validationTester = ValidationTester(
                 req = { params: Map<String, Any?> ->
@@ -197,9 +192,8 @@ internal class PostControllerTest @Autowired constructor(
                 )
             )
 
-            @Nested
+            @NestedTest
             @DisplayName("title")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class TitleValidation {
                 @BeforeAll
                 fun setParam() {
@@ -214,9 +208,8 @@ internal class PostControllerTest @Autowired constructor(
                 fun size() = validationTester.hasSizeBetween(Constants.Title.minSize, Constants.Title.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("body")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class BodyValidation {
                 @BeforeAll
                 fun setParam() {
@@ -231,9 +224,8 @@ internal class PostControllerTest @Autowired constructor(
                 fun size() = validationTester.hasMinSize(Constants.Body.minSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("thumbnailPath")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class ThumbnailValidation {
                 @BeforeAll
                 fun setParam() {
@@ -247,10 +239,8 @@ internal class PostControllerTest @Autowired constructor(
                 fun `should not be empty`() = validationTester.isNotEmpty()
             }
 
-            @Nested
-            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
+            @NestedTest
             @DisplayName("slug")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class SlugValidation {
                 @BeforeAll
                 fun setParam() {
@@ -264,7 +254,7 @@ internal class PostControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("DELETE /posts/{postId}")
     inner class DeletePost {
         @BeforeEach
@@ -294,9 +284,8 @@ internal class PostControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("PUT /posts/{postId}")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class UpdatePost {
         @BeforeAll
         fun addPost() {
@@ -433,9 +422,8 @@ internal class PostControllerTest @Autowired constructor(
                 }
         }
 
-        @Nested
+        @NestedTest
         @DisplayName("Input Validation")
-        @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
         inner class InputValidation {
             private val validationTester = ValidationTester(
                 req = { params: Map<String, Any?> ->
@@ -451,9 +439,8 @@ internal class PostControllerTest @Autowired constructor(
                 )
             )
 
-            @Nested
+            @NestedTest
             @DisplayName("title")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class TitleValidation {
                 @BeforeAll
                 fun setParam() {
@@ -468,9 +455,8 @@ internal class PostControllerTest @Autowired constructor(
                 fun size() = validationTester.hasSizeBetween(Constants.Title.minSize, Constants.Title.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("body")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class BodyValidation {
                 @BeforeAll
                 fun setParam() {
@@ -485,9 +471,8 @@ internal class PostControllerTest @Autowired constructor(
                 fun size() = validationTester.hasMinSize(Constants.Body.minSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("thumbnailPath")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class ThumbnailValidation {
                 @BeforeAll
                 fun setParam() {
@@ -501,10 +486,8 @@ internal class PostControllerTest @Autowired constructor(
                 fun `should not be empty`() = validationTester.isNotEmpty()
             }
 
-            @Nested
-            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
+            @NestedTest
             @DisplayName("slug")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class SlugValidation {
                 @BeforeAll
                 fun setParam() {

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
@@ -10,11 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.NestedTestConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
@@ -24,14 +20,12 @@ import org.springframework.test.web.servlet.put
 import pt.up.fe.ni.website.backend.model.Post
 import pt.up.fe.ni.website.backend.repository.PostRepository
 import pt.up.fe.ni.website.backend.utils.ValidationTester
+import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import java.text.SimpleDateFormat
 import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureTestDatabase
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ControllerTest
 internal class PostControllerTest @Autowired constructor(
     val mockMvc: MockMvc,
     val objectMapper: ObjectMapper,
@@ -187,6 +181,7 @@ internal class PostControllerTest @Autowired constructor(
 
         @Nested
         @DisplayName("Input Validation")
+        @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
         inner class InputValidation {
             private val validationTester = ValidationTester(
                 req = { params: Map<String, Any?> ->
@@ -203,7 +198,6 @@ internal class PostControllerTest @Autowired constructor(
             )
 
             @Nested
-            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
             @DisplayName("title")
             @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class TitleValidation {
@@ -221,7 +215,6 @@ internal class PostControllerTest @Autowired constructor(
             }
 
             @Nested
-            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
             @DisplayName("body")
             @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class BodyValidation {
@@ -442,6 +435,7 @@ internal class PostControllerTest @Autowired constructor(
 
         @Nested
         @DisplayName("Input Validation")
+        @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
         inner class InputValidation {
             private val validationTester = ValidationTester(
                 req = { params: Map<String, Any?> ->
@@ -458,7 +452,6 @@ internal class PostControllerTest @Autowired constructor(
             )
 
             @Nested
-            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
             @DisplayName("title")
             @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class TitleValidation {
@@ -476,7 +469,6 @@ internal class PostControllerTest @Autowired constructor(
             }
 
             @Nested
-            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
             @DisplayName("body")
             @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class BodyValidation {
@@ -494,7 +486,6 @@ internal class PostControllerTest @Autowired constructor(
             }
 
             @Nested
-            @NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
             @DisplayName("thumbnailPath")
             @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class ThumbnailValidation {

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -163,7 +163,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @NestedTest
+    @EndpointTest
     @DisplayName("DELETE /projects/{projectId}")
     inner class DeleteProject {
         @BeforeEach
@@ -193,7 +193,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @NestedTest
+    @EndpointTest
     @DisplayName("PUT /projects/{projectId}")
     inner class UpdateProject {
         @BeforeEach
@@ -301,7 +301,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @NestedTest
+    @EndpointTest
     @DisplayName("PUT /projects/{projectId}/archive")
     inner class ArchiveProject {
         @BeforeEach
@@ -328,7 +328,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @NestedTest
+    @EndpointTest
     @DisplayName("PUT /projects/{projectId}/unarchive")
     inner class UnarchiveProject {
         private val project = Project(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -9,11 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
@@ -22,12 +18,10 @@ import org.springframework.test.web.servlet.put
 import pt.up.fe.ni.website.backend.model.Project
 import pt.up.fe.ni.website.backend.repository.ProjectRepository
 import pt.up.fe.ni.website.backend.utils.ValidationTester
+import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants as Constants
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureTestDatabase
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ControllerTest
 internal class ProjectControllerTest @Autowired constructor(
     val mockMvc: MockMvc,
     val objectMapper: ObjectMapper,

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -19,6 +17,8 @@ import pt.up.fe.ni.website.backend.model.Project
 import pt.up.fe.ni.website.backend.repository.ProjectRepository
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
+import pt.up.fe.ni.website.backend.utils.annotations.EndpointTest
+import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants as Constants
 
 @ControllerTest
@@ -34,9 +34,8 @@ internal class ProjectControllerTest @Autowired constructor(
         listOf("Java", "Kotlin", "Spring")
     )
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /projects")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetAllProjects {
         private val testProjects = listOf(
             testProject,
@@ -63,9 +62,8 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("GET /projects/{projectId}")
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class GetProject {
         @BeforeAll
         fun addProject() {
@@ -95,7 +93,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @EndpointTest
     @DisplayName("POST /projects/new")
     inner class CreateProject {
         @Test
@@ -114,7 +112,7 @@ internal class ProjectControllerTest @Autowired constructor(
                 }
         }
 
-        @Nested
+        @NestedTest
         @DisplayName("Input Validation")
         inner class InputValidation {
             private val validationTester = ValidationTester(
@@ -130,9 +128,8 @@ internal class ProjectControllerTest @Autowired constructor(
                 )
             )
 
-            @Nested
+            @NestedTest
             @DisplayName("title")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class TitleValidation {
                 @BeforeAll
                 fun setParam() {
@@ -147,9 +144,8 @@ internal class ProjectControllerTest @Autowired constructor(
                 fun size() = validationTester.hasSizeBetween(Constants.Title.minSize, Constants.Title.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("description")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class DescriptionValidation {
                 @BeforeAll
                 fun setParam() {
@@ -167,7 +163,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @NestedTest
     @DisplayName("DELETE /projects/{projectId}")
     inner class DeleteProject {
         @BeforeEach
@@ -197,7 +193,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @NestedTest
     @DisplayName("PUT /projects/{projectId}")
     inner class UpdateProject {
         @BeforeEach
@@ -254,7 +250,7 @@ internal class ProjectControllerTest @Autowired constructor(
                 }
         }
 
-        @Nested
+        @NestedTest
         @DisplayName("Input Validation")
         inner class InputValidation {
             private val validationTester = ValidationTester(
@@ -270,9 +266,8 @@ internal class ProjectControllerTest @Autowired constructor(
                 )
             )
 
-            @Nested
+            @NestedTest
             @DisplayName("title")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class TitleValidation {
                 @BeforeAll
                 fun setParam() {
@@ -287,9 +282,8 @@ internal class ProjectControllerTest @Autowired constructor(
                 fun size() = validationTester.hasSizeBetween(Constants.Title.minSize, Constants.Title.maxSize)
             }
 
-            @Nested
+            @NestedTest
             @DisplayName("description")
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
             inner class BodyValidation {
                 @BeforeAll
                 fun setParam() {
@@ -307,7 +301,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @NestedTest
     @DisplayName("PUT /projects/{projectId}/archive")
     inner class ArchiveProject {
         @BeforeEach
@@ -334,7 +328,7 @@ internal class ProjectControllerTest @Autowired constructor(
         }
     }
 
-    @Nested
+    @NestedTest
     @DisplayName("PUT /projects/{projectId}/unarchive")
     inner class UnarchiveProject {
         private val project = Project(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/annotations/ControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/annotations/ControllerTest.kt
@@ -1,0 +1,14 @@
+package pt.up.fe.ni.website.backend.utils.annotations
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+internal annotation class ControllerTest

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/annotations/EndpointTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/annotations/EndpointTest.kt
@@ -1,0 +1,10 @@
+package pt.up.fe.ni.website.backend.utils.annotations
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.TestInstance
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Nested
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal annotation class EndpointTest

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/annotations/NestedTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/annotations/NestedTest.kt
@@ -1,0 +1,12 @@
+package pt.up.fe.ni.website.backend.utils.annotations
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.TestInstance
+import org.springframework.test.context.NestedTestConfiguration
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Nested
+@NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal annotation class NestedTest


### PR DESCRIPTION
For context, @jamcunha was having some problems when using the `@BeforeAll` feature in nested test classes. We then found out that happened because of a misconfiguration where the context was being discarded but the test instance was not over (using class life cycle). We found the solution for that but I realized the annotations in the test classes were getting way too verbose and hard to understand.

Therefore, I tried to find a solution to simplify test writing and avoid confusing when copying random annotations from somewhere else. I liked the solution of creating custom annotations serving as a composition of meta-annotations. This PR also ensures test consistency by using the following pattern:
- Base classes for integration tests are marked with `@ControllerTest`, which configures SpringBootTest, MVC, DB, and marks the dirty context after a test class.
- Inner classes testing endpoints (which always happens in our tests) are marked with `@EndpointTest`. This marks the class with `@Nested` and changes the test instance to `PER_CLASS` life cycle, which ensures we can use features such as `@BeforeAll`.
- Additional inner test classes are marked with `@NestedTest`. This is where @jamcunha's solution was moved to. Here, the configuration is reset (w/ `@NestedTestConfiguration(NestedTestConfiguration.EnclosingConfiguration.OVERRIDE)`) to make sure the context is not invalidated in these classes (dirty context). This avoids the bug mentioned above and improves performance since unnecessary context reloads are not done anymore.

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
