### PR TITLE
Simplified error message

### DIFF
--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Account.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Account.kt
@@ -54,7 +54,7 @@ class Account(
 
     @JoinColumn
     @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
-    val websites: List<@Valid CustomWebsite>,
+    val websites: List<@Valid CustomWebsite> = emptyList(),
 
     @Id @GeneratedValue
     val id: Long? = null

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/AccountService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/AccountService.kt
@@ -16,6 +16,8 @@ class AccountService(private val repository: AccountRepository, private val enco
             throw IllegalArgumentException(ErrorMessages.emailAlreadyExists)
         }
 
+        requireNotNull(dto.websites) { "'websites' is missing" }
+
         val account = dto.create()
         account.password = encoder.encode(dto.password)
         return repository.save(account)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/AccountService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/AccountService.kt
@@ -16,8 +16,6 @@ class AccountService(private val repository: AccountRepository, private val enco
             throw IllegalArgumentException(ErrorMessages.emailAlreadyExists)
         }
 
-        requireNotNull(dto.websites) { "'websites' is missing" }
-
         val account = dto.create()
         account.password = encoder.encode(dto.password)
         return repository.save(account)

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -142,6 +142,35 @@ class AccountControllerTest @Autowired constructor(
                 jsonPath("$.websites[0].iconPath") { value(testAccount.websites[0].iconPath) }
             }
         }
+        @Test
+        fun `should create an account with a empty website list`() {
+            val noWebsite = Account(
+                "Test Account",
+                "no_website@email.com",
+                "test_password",
+                "This is a test account",
+                TestUtils.createDate(2001, Calendar.JULY, 28),
+                "https://test-photo.com",
+                "https://linkedin.com",
+                "https://github.com"
+            )
+
+            mockMvc.post("/accounts/new") {
+                contentType = MediaType.APPLICATION_JSON
+                content = noWebsite.toJson()
+            }.andExpect {
+                status { isOk() }
+                content { contentType(MediaType.APPLICATION_JSON) }
+                jsonPath("$.name") { value(noWebsite.name) }
+                jsonPath("$.email") { value(noWebsite.email) }
+                jsonPath("$.bio") { value(noWebsite.bio) }
+                jsonPath("$.birthDate") { value(noWebsite.birthDate.toJson()) }
+                jsonPath("$.photoPath") { value(noWebsite.photoPath) }
+                jsonPath("$.linkedin") { value(noWebsite.linkedin) }
+                jsonPath("$.github") { value(noWebsite.github) }
+                jsonPath("$.websites.length()") { value(0) }
+            }
+        }
 
         @NestedTest
         @DisplayName("Input Validation")

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -143,7 +143,7 @@ class AccountControllerTest @Autowired constructor(
             }
         }
         @Test
-        fun `should create an account with a empty website list`() {
+        fun `should create an account with an empty website list`() {
             val noWebsite = Account(
                 "Test Account",
                 "no_website@email.com",
@@ -157,7 +157,18 @@ class AccountControllerTest @Autowired constructor(
 
             mockMvc.post("/accounts/new") {
                 contentType = MediaType.APPLICATION_JSON
-                content = noWebsite.toJson()
+                content = objectMapper.writeValueAsString(
+                    mapOf(
+                        "name" to noWebsite.name,
+                        "email" to noWebsite.email,
+                        "password" to noWebsite.password,
+                        "bio" to noWebsite.bio,
+                        "birthDate" to noWebsite.birthDate,
+                        "photoPath" to noWebsite.photoPath,
+                        "linkedin" to noWebsite.linkedin,
+                        "github" to noWebsite.github
+                    )
+                )
             }.andExpect {
                 status { isOk() }
                 content { contentType(MediaType.APPLICATION_JSON) }


### PR DESCRIPTION
Closes #90 

Simplified error message when "websites" field is missing.

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [ ] Contains enough appropriate tests
-   [x] Behavior is as expected
-   [ ] Clean, well structured code
