### PR TITLE
Use global editorconfig and reformat files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,4 @@ max_line_length = 120
 [*.{kt,kts}]
 ktlint_code_style = android
 ktlint_version = 0.48.2
-ktlint_disabled_rules = import-ordering # ktlint IntelliJ IDEA extension seems to disagree with ktlint CLI
+ij_kotlin_imports_layout=*

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+
+[*.{kt,kts}]
+ktlint_code_style = android
+ktlint_version = 0.48.2
+ktlint_disabled_rules = import-ordering # ktlint IntelliJ IDEA extension seems to disagree with ktlint CLI

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("jvm") version "1.7.21"
     kotlin("plugin.spring") version "1.7.21"
     kotlin("plugin.jpa") version "1.7.21"
-    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.2.0"
     jacoco
 }
 

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/annotations/validation/ValidDateInterval.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/annotations/validation/ValidDateInterval.kt
@@ -4,8 +4,8 @@ import jakarta.validation.Constraint
 import jakarta.validation.ConstraintValidator
 import jakarta.validation.ConstraintValidatorContext
 import jakarta.validation.Payload
-import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 import kotlin.reflect.KClass
+import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/config/auth/AuthConfig.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/config/auth/AuthConfig.kt
@@ -50,7 +50,9 @@ class AuthConfig(
 
     @Bean
     fun jwtEncoder(): JwtEncoder {
-        val jwt = RSAKey.Builder(authConfigProperties::publicKey.get()).privateKey(authConfigProperties::privateKey.get()).build()
+        val jwt = RSAKey.Builder(authConfigProperties::publicKey.get()).privateKey(
+            authConfigProperties::privateKey.get()
+        ).build()
         return NimbusJwtEncoder(ImmutableJWKSet(JWKSet(jwt)))
     }
 

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/config/auth/AuthConfigProperties.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/config/auth/AuthConfigProperties.kt
@@ -1,8 +1,8 @@
 package pt.up.fe.ni.website.backend.config.auth
 
-import org.springframework.boot.context.properties.ConfigurationProperties
 import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
+import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "auth")
 data class AuthConfigProperties(

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/AccountDto.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/AccountDto.kt
@@ -1,7 +1,7 @@
 package pt.up.fe.ni.website.backend.dto.entity
 
-import pt.up.fe.ni.website.backend.model.Account
 import java.util.Date
+import pt.up.fe.ni.website.backend.model.Account
 
 class AccountDto(
     val email: String,

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/EntityDto.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/dto/entity/EntityDto.kt
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.persistence.Entity
 import jakarta.validation.ConstraintViolationException
 import jakarta.validation.Validator
-import pt.up.fe.ni.website.backend.config.ApplicationContextUtils
 import kotlin.reflect.KClass
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.jvm.jvmErasure
+import pt.up.fe.ni.website.backend.config.ApplicationContextUtils
 
 abstract class EntityDto<T : Any> {
 

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Account.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Account.kt
@@ -15,11 +15,11 @@ import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Past
 import jakarta.validation.constraints.Size
+import java.util.Date
 import org.hibernate.validator.constraints.URL
 import pt.up.fe.ni.website.backend.annotations.validation.NullOrNotBlank
-import pt.up.fe.ni.website.backend.model.permissions.Permissions
-import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
+import pt.up.fe.ni.website.backend.model.permissions.Permissions
 
 @Entity
 class Account(

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Event.kt
@@ -8,8 +8,8 @@ import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
 import org.hibernate.validator.constraints.URL
 import pt.up.fe.ni.website.backend.annotations.validation.NullOrNotBlank
-import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
+import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 
 @Entity
 class Event(

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Post.kt
@@ -9,11 +9,11 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Size
+import java.util.Date
 import org.hibernate.validator.constraints.URL
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import java.util.Date
 import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
 
 @Entity

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Role.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Role.kt
@@ -35,6 +35,7 @@ class Role(
     var associatedActivities: List<@Valid PerActivityRole> = emptyList(),
 
     @JsonProperty(required = true)
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue
     val id: Long? = null
 )

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/embeddable/DateInterval.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/embeddable/DateInterval.kt
@@ -2,8 +2,8 @@ package pt.up.fe.ni.website.backend.model.embeddable
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.persistence.Embeddable
-import pt.up.fe.ni.website.backend.annotations.validation.ValidDateInterval
 import java.util.Date
+import pt.up.fe.ni.website.backend.annotations.validation.ValidDateInterval
 
 @ValidDateInterval
 @Embeddable

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/ActivityService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/ActivityService.kt
@@ -22,11 +22,13 @@ abstract class ActivityService<T : Activity>(
 
     fun removeTeamMemberById(idActivity: Long, idAccount: Long): T {
         val activity = getActivityById(idActivity)
-        if (!accountService.doesAccountExist(idAccount)) throw NoSuchElementException(
-            ErrorMessages.accountNotFound(
-                idAccount
+        if (!accountService.doesAccountExist(idAccount)) {
+            throw NoSuchElementException(
+                ErrorMessages.accountNotFound(
+                    idAccount
+                )
             )
-        )
+        }
         activity.teamMembers.removeIf { it.id == idAccount }
         return repository.save(activity)
     }

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/AuthService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/AuthService.kt
@@ -1,5 +1,8 @@
 package pt.up.fe.ni.website.backend.service
 
+import java.time.Duration
+import java.time.Instant
+import java.util.stream.Collectors
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -13,9 +16,6 @@ import org.springframework.security.oauth2.server.resource.InvalidBearerTokenExc
 import org.springframework.stereotype.Service
 import pt.up.fe.ni.website.backend.config.auth.AuthConfigProperties
 import pt.up.fe.ni.website.backend.model.Account
-import java.time.Duration
-import java.time.Instant
-import java.util.stream.Collectors
 
 @Service
 class AuthService(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -1,6 +1,8 @@
 package pt.up.fe.ni.website.backend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.Calendar
+import java.util.Date
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -13,14 +15,12 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
+import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
-import java.util.Calendar
-import java.util.Date
-import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
 
 @ControllerTest
 class AccountControllerTest @Autowired constructor(
@@ -144,6 +144,7 @@ class AccountControllerTest @Autowired constructor(
                 jsonPath("$.websites[0].iconPath") { value(testAccount.websites[0].iconPath) }
             }
         }
+
         @Test
         fun `should create an account with an empty website list`() {
             val noWebsite = Account(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
@@ -43,7 +43,7 @@ class AuthControllerTest @Autowired constructor(
         listOf(
             CustomWebsite("https://test-website.com", "https://test-website.com/logo.png")
         ),
-        emptyList(),
+        emptyList()
     )
 
     @NestedTest

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
@@ -1,6 +1,7 @@
 package pt.up.fe.ni.website.backend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.Calendar
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -19,7 +20,6 @@ import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
-import java.util.Calendar
 
 @ControllerTest
 class AuthControllerTest @Autowired constructor(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -277,7 +277,10 @@ internal class EventControllerTest @Autowired constructor(
                 fun `should be required`() = validationTester.isRequired()
 
                 @Test
-                @DisplayName("size should be between ${ActivityConstants.Title.minSize} and ${ActivityConstants.Title.maxSize}()")
+                @DisplayName(
+                    "size should be between ${ActivityConstants.Title.minSize}" +
+                        " and ${ActivityConstants.Title.maxSize}()"
+                )
                 fun size() =
                     validationTester.hasSizeBetween(ActivityConstants.Title.minSize, ActivityConstants.Title.maxSize)
             }
@@ -294,7 +297,10 @@ internal class EventControllerTest @Autowired constructor(
                 fun `should be required`() = validationTester.isRequired()
 
                 @Test
-                @DisplayName("size should be between ${ActivityConstants.Description.minSize} and ${ActivityConstants.Description.maxSize}()")
+                @DisplayName(
+                    "size should be between ${ActivityConstants.Description.minSize}" +
+                        " and ${ActivityConstants.Description.maxSize}()"
+                )
                 fun size() =
                     validationTester.hasSizeBetween(
                         ActivityConstants.Description.minSize,
@@ -626,7 +632,10 @@ internal class EventControllerTest @Autowired constructor(
                 fun `should be required`() = validationTester.isRequired()
 
                 @Test
-                @DisplayName("size should be between ${ActivityConstants.Title.minSize} and ${ActivityConstants.Title.maxSize}()")
+                @DisplayName(
+                    "size should be between ${ActivityConstants.Title.minSize}" +
+                        " and ${ActivityConstants.Title.maxSize}()"
+                )
                 fun size() =
                     validationTester.hasSizeBetween(
                         ActivityConstants.Title.minSize,
@@ -646,7 +655,10 @@ internal class EventControllerTest @Autowired constructor(
                 fun `should be required`() = validationTester.isRequired()
 
                 @Test
-                @DisplayName("size should be between ${ActivityConstants.Description.minSize} and ${ActivityConstants.Description.maxSize}()")
+                @DisplayName(
+                    "size should be between ${ActivityConstants.Description.minSize} " +
+                        "and ${ActivityConstants.Description.maxSize}()"
+                )
                 fun size() =
                     validationTester.hasSizeBetween(
                         ActivityConstants.Description.minSize,

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -1,6 +1,8 @@
 package pt.up.fe.ni.website.backend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.Calendar
+import java.util.Date
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -17,6 +19,7 @@ import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants
+import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
 import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.repository.EventRepository
@@ -24,9 +27,6 @@ import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
-import java.util.Calendar
-import java.util.Date
-import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
 
 @ControllerTest
 internal class EventControllerTest @Autowired constructor(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
@@ -1,6 +1,8 @@
 package pt.up.fe.ni.website.backend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.text.SimpleDateFormat
+import java.util.Date
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeAll
@@ -15,13 +17,11 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
 import pt.up.fe.ni.website.backend.model.Post
+import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
 import pt.up.fe.ni.website.backend.repository.PostRepository
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
-import java.text.SimpleDateFormat
-import java.util.Date
-import pt.up.fe.ni.website.backend.model.constants.PostConstants as Constants
 
 @ControllerTest
 internal class PostControllerTest @Autowired constructor(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -1,6 +1,8 @@
 package pt.up.fe.ni.website.backend.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.Calendar
+import java.util.Date
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -16,15 +18,13 @@ import org.springframework.test.web.servlet.put
 import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.model.Project
+import pt.up.fe.ni.website.backend.model.constants.ActivityConstants as Constants
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.repository.ProjectRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
 import pt.up.fe.ni.website.backend.utils.annotations.ControllerTest
 import pt.up.fe.ni.website.backend.utils.annotations.NestedTest
-import java.util.Calendar
-import java.util.Date
-import pt.up.fe.ni.website.backend.model.constants.ActivityConstants as Constants
 
 @ControllerTest
 internal class ProjectControllerTest @Autowired constructor(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -198,7 +198,10 @@ internal class ProjectControllerTest @Autowired constructor(
                 fun `should be required`() = validationTester.isRequired()
 
                 @Test
-                @DisplayName("size should be between ${Constants.Description.minSize} and ${Constants.Description.maxSize}()")
+                @DisplayName(
+                    "size should be between ${Constants.Description.minSize} " +
+                        "and ${Constants.Description.maxSize}()"
+                )
                 fun size() =
                     validationTester.hasSizeBetween(Constants.Description.minSize, Constants.Description.maxSize)
             }
@@ -342,7 +345,10 @@ internal class ProjectControllerTest @Autowired constructor(
                 fun `should be required`() = validationTester.isRequired()
 
                 @Test
-                @DisplayName("size should be between ${Constants.Description.minSize} and ${Constants.Description.maxSize}()")
+                @DisplayName(
+                    "size should be between ${Constants.Description.minSize}" +
+                        " and ${Constants.Description.maxSize}()"
+                )
                 fun size() =
                     validationTester.hasSizeBetween(Constants.Description.minSize, Constants.Description.maxSize)
             }

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
@@ -2,14 +2,14 @@ package pt.up.fe.ni.website.backend.utils.listeners
 
 import jakarta.persistence.EntityManager
 import jakarta.transaction.Transactional
+import java.sql.Connection
+import java.sql.Statement
+import javax.sql.DataSource
 import org.hibernate.id.enhanced.PooledOptimizer
 import org.hibernate.id.enhanced.SequenceStyleGenerator
 import org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl
 import org.springframework.test.context.TestContext
 import org.springframework.test.context.TestExecutionListener
-import java.sql.Connection
-import java.sql.Statement
-import javax.sql.DataSource
 
 class DbCleanupListener : TestExecutionListener {
     companion object {

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
@@ -40,7 +40,10 @@ class DbCleanupListener : TestExecutionListener {
             resetSequences(statement)
             enableConstraints(statement)
         } else {
-            print("Unexpected database type: ${connection.metaData.databaseProductName} (expected: $DB_NAME). Skipping cleanup.")
+            print(
+                "Unexpected database type: ${connection.metaData.databaseProductName}" +
+                    " (expected: $DB_NAME). Skipping cleanup."
+            )
         }
     }
 
@@ -52,7 +55,9 @@ class DbCleanupListener : TestExecutionListener {
         metaModel.forEachEntityDescriptor { entityDescriptor ->
             if (!entityDescriptor.hasIdentifierProperty() ||
                 entityDescriptor.identifierGenerator !is SequenceStyleGenerator
-            ) return@forEachEntityDescriptor
+            ) {
+                return@forEachEntityDescriptor
+            }
 
             val sequenceStyleGenerator = (entityDescriptor.identifierGenerator as SequenceStyleGenerator)
             val optimizer = sequenceStyleGenerator.optimizer as? PooledOptimizer


### PR DESCRIPTION
Closes #101 

Adds an [`.editorconfig`](https://editorconfig.org/) to the project to enforce standards such as max line length, spaces instead of tabs but also to provide kotlin style configuration proprietary to `ktlint`: plugin version, disabled rules and used style. The chosen style is [Android's](https://developer.android.com/kotlin/style-guide) instead of the official one, since it is more rigid and opinionated, which in my opinion is always a good thing.

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
