### PR TITLE
Fixed flaky test using equal dates

### DIFF
--- a/src/test/kotlin/pt/up/fe/ni/website/backend/annotations/validation/DateIntervalTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/annotations/validation/DateIntervalTest.kt
@@ -52,13 +52,14 @@ internal class DateIntervalTest {
 
     @Test
     fun `should fail when endDate is equal to startDate`() {
+        val date = TestUtils.createDate(2022, 12, 6)
         val validator = DateIntervalValidator()
         validator.initialize(ValidDateInterval())
         assert(
             !validator.isValid(
                 DateInterval(
-                    TestUtils.createDate(2022, 12, 6),
-                    TestUtils.createDate(2022, 12, 6)
+                    date,
+                    date
                 ),
                 null
             )


### PR DESCRIPTION
There was a test failing sometimes because the date being generated was supposed to be equal but sometimes there was a race condition setting the dates as not strictly equal (timestamps shenanigans). I fixed by only using 1 variable

[Description of the changes proposed in the pull request]

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
