### PR TITLE
Added Logging interface

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,11 +29,14 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+    implementation("ch.qos.logback:logback-core:1.4.5")
+    implementation("org.slf4j:slf4j-api:2.0.6")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-validation:3.0.0")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("ch.qos.logback:logback-classic:1.4.5")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/config/Logger.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/config/Logger.kt
@@ -1,0 +1,8 @@
+package pt.up.fe.ni.website.backend.config
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory.getLogger
+
+interface Logging
+
+inline fun <reified T : Logging> T.logger(): Logger = getLogger(T::class.java)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/config/Logging.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/config/Logging.kt
@@ -3,6 +3,6 @@ package pt.up.fe.ni.website.backend.config
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory.getLogger
 
-interface Logging
-
-inline fun <reified T : Logging> T.logger(): Logger = getLogger(T::class.java)
+interface Logging {
+    val logger: Logger get() = getLogger(this::class.java)
+}

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import pt.up.fe.ni.website.backend.config.Logging
-import pt.up.fe.ni.website.backend.config.logger
 
 data class SimpleError(
     val message: String,
@@ -94,7 +93,7 @@ class ErrorController : ErrorController, Logging {
     @ExceptionHandler(Exception::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     fun unexpectedError(e: Exception): CustomError {
-        logger().error(e.message)
+        logger.error(e.message)
         return wrapSimpleError("unexpected error: " + e.message)
     }
 

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ErrorController.kt
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import pt.up.fe.ni.website.backend.config.Logging
+import pt.up.fe.ni.website.backend.config.logger
 
 data class SimpleError(
     val message: String,
@@ -25,7 +27,7 @@ data class CustomError(val errors: List<SimpleError>)
 
 @RestController
 @RestControllerAdvice
-class ErrorController : ErrorController {
+class ErrorController : ErrorController, Logging {
 
     @RequestMapping("/**")
     @ResponseStatus(HttpStatus.NOT_FOUND)
@@ -92,7 +94,7 @@ class ErrorController : ErrorController {
     @ExceptionHandler(Exception::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     fun unexpectedError(e: Exception): CustomError {
-        System.err.println(e)
+        logger().error(e.message)
         return wrapSimpleError("unexpected error: " + e.message)
     }
 

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
@@ -11,7 +11,6 @@ import org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl
 import org.springframework.test.context.TestContext
 import org.springframework.test.context.TestExecutionListener
 import pt.up.fe.ni.website.backend.config.Logging
-import pt.up.fe.ni.website.backend.config.logger
 
 class DbCleanupListener : TestExecutionListener, Logging {
     companion object {
@@ -21,7 +20,7 @@ class DbCleanupListener : TestExecutionListener, Logging {
 
     override fun beforeTestMethod(testContext: TestContext) {
         super.beforeTestMethod(testContext)
-        logger().info("Cleaning up database...")
+        logger.info("Cleaning up database...")
 
         val dataSource = testContext.applicationContext.getBean(DataSource::class.java)
         cleanDataSource(dataSource)
@@ -29,7 +28,7 @@ class DbCleanupListener : TestExecutionListener, Logging {
         val entityManager = testContext.applicationContext.getBean(EntityManager::class.java)
         cleanEntityManager(entityManager)
 
-        logger().info("Done cleaning up database...")
+        logger.info("Done cleaning up database...")
     }
 
     @Transactional(Transactional.TxType.REQUIRES_NEW)
@@ -42,7 +41,7 @@ class DbCleanupListener : TestExecutionListener, Logging {
             resetSequences(statement)
             enableConstraints(statement)
         } else {
-            logger().warn(
+            logger.warn(
                 "Unexpected database type: ${connection.metaData.databaseProductName}" +
                     " (expected: $DB_NAME). Skipping cleanup."
             )

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/listeners/DbCleanupListener.kt
@@ -10,8 +10,10 @@ import org.hibernate.id.enhanced.SequenceStyleGenerator
 import org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl
 import org.springframework.test.context.TestContext
 import org.springframework.test.context.TestExecutionListener
+import pt.up.fe.ni.website.backend.config.Logging
+import pt.up.fe.ni.website.backend.config.logger
 
-class DbCleanupListener : TestExecutionListener {
+class DbCleanupListener : TestExecutionListener, Logging {
     companion object {
         private const val SCHEMA_NAME = "PUBLIC"
         private const val DB_NAME = "H2"
@@ -19,7 +21,7 @@ class DbCleanupListener : TestExecutionListener {
 
     override fun beforeTestMethod(testContext: TestContext) {
         super.beforeTestMethod(testContext)
-        println("Cleaning up database...")
+        logger().info("Cleaning up database...")
 
         val dataSource = testContext.applicationContext.getBean(DataSource::class.java)
         cleanDataSource(dataSource)
@@ -27,7 +29,7 @@ class DbCleanupListener : TestExecutionListener {
         val entityManager = testContext.applicationContext.getBean(EntityManager::class.java)
         cleanEntityManager(entityManager)
 
-        println("Done cleaning database.")
+        logger().info("Done cleaning up database...")
     }
 
     @Transactional(Transactional.TxType.REQUIRES_NEW)
@@ -40,7 +42,7 @@ class DbCleanupListener : TestExecutionListener {
             resetSequences(statement)
             enableConstraints(statement)
         } else {
-            print(
+            logger().warn(
                 "Unexpected database type: ${connection.metaData.databaseProductName}" +
                     " (expected: $DB_NAME). Skipping cleanup."
             )


### PR DESCRIPTION

Closes #32 

Adds a proper logging interface based on SLF4J API and Logback. Classes that require using the logger should now implement the Logging interface and refer to logger().

# Review checklist
-   [ ] Properly documents API changes in `docs/openapi.yml`
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
