### PR TITLE
Docs/readme generate docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+docs/
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Run the following command in your shell:
 ### API Documentation
 API documentation is generated through the use of the [Spring REST Docs API specification Integration (aka restdocs-api-spec)](https://github.com/ePages-de/restdocs-api-spec), a [Spring Rest Docs](https://spring.io/projects/spring-restdocs) extension that builds an [OpenAPI specification](https://www.openapis.org/) or a [Postman collection](https://learning.postman.com/docs/sending-requests/intro-to-collections/) from its description, included in the controller tests. To see examples of how to document the API, hop to one of the controller tests and read the [API documentation wiki page](https://github.com/NIAEFEUP/website-niaefeup-backend/wiki/API-documentation).
 
+Find the current version of the API documentation [here](https://develop--niaefeup-backend-docs.netlify.app/).
+
+The Postman collection is also available [here](https://develop--niaefeup-backend-docs.netlify.app/postman-collection.json).
+
 ##### With IntelliJ
 Run the `generateDocs` gradle task to generate the OpenAPI specification or the Postman collection.
 

--- a/README.md
+++ b/README.md
@@ -74,24 +74,20 @@ Run the following command in your shell:
 
 
 ### API Documentation
-API documentation is generated through the use of the [Spring REST Docs API specification Integration (aka restdocs-api-spec)](https://github.com/ePages-de/restdocs-api-spec), a [Spring Rest Docs](https://spring.io/projects/spring-restdocs) extension that builds an [OpenAPI](https://www.openapis.org/) or a [Postman collection](https://learning.postman.com/docs/sending-requests/intro-to-collections/) specification from its description, included in the controller tests. To see examples of how to document the API hop to one of the controller tests and read the [API documentation wiki page](https://github.com/NIAEFEUP/website-niaefeup-backend/wiki/API-documentation).
+API documentation is generated through the use of the [Spring REST Docs API specification Integration (aka restdocs-api-spec)](https://github.com/ePages-de/restdocs-api-spec), a [Spring Rest Docs](https://spring.io/projects/spring-restdocs) extension that builds an [OpenAPI specification](https://www.openapis.org/) or a [Postman collection](https://learning.postman.com/docs/sending-requests/intro-to-collections/) from its description, included in the controller tests. To see examples of how to document the API, hop to one of the controller tests and read the [API documentation wiki page](https://github.com/NIAEFEUP/website-niaefeup-backend/wiki/API-documentation).
 
 ##### With IntelliJ
-Run the `openapi3` or `postman` gradle task to get either the OpenAPI specification or the Postman collection respectively.
+Run the `generateDocs` gradle task to generate the OpenAPI specification or the Postman collection.
 
 ##### With the command line
 Run the following command in your shell:
 
 ```bash
-./gradlew openapi3
-```
-
-```bash
-./gradlew postman
+./gradlew generateDocs
 ```
 
 ###### Results
-Find the OpenAPI specification under `build/api-spec/openapi3.json` after running the task or the resulting Postman collection under `build/api-spec/postman-collection.json`.
+Find the OpenAPI specification and Postman collection under `docs/` after running the task.
 
 
 ## Project Details

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,8 @@ val apiSpecTitle = "NIAEFEUP Website - Backend API specification"
 val apiSpecDescription =
     """This specification documents the available endpoints and possible operations on the website's backend.
         |For each of the operations, its purpose, security, requests and possible responses are documented.
+        |
+        |Postman collection also available <a href="postman-collection.json" download>here</a>.
     """.trimMargin()
 
 configure<com.epages.restdocs.apispec.gradle.OpenApi3Extension> {


### PR DESCRIPTION
Closes #135 

- Update ReadMe to mention the `generateDocs` task instead of the separate `openapi3` and `postman` tasks.
- Update `gitignore` to hide the `docs/` folder generated by the task

# Review checklist
-   [ ] Properly documents API changes in the corresponding controller test
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
