### PR TITLE
Fixed startup error related to final Activity fields

### DIFF
--- a/src/main/kotlin/pt/up/fe/ni/website/backend/model/Activity.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/model/Activity.kt
@@ -22,26 +22,26 @@ import pt.up.fe.ni.website.backend.model.constants.ActivityConstants as Constant
 abstract class Activity(
     @JsonProperty(required = true)
     @field:Size(min = Constants.Title.minSize, max = Constants.Title.maxSize)
-    var title: String,
+    open var title: String,
 
     @JsonProperty(required = true)
     @field:Size(min = Constants.Description.minSize, max = Constants.Description.maxSize)
-    var description: String,
+    open var description: String,
 
     @JoinColumn
     @OneToMany(fetch = FetchType.EAGER)
-    val teamMembers: MutableList<Account>,
+    open val teamMembers: MutableList<Account>,
 
     @OneToMany(cascade = [CascadeType.ALL], mappedBy = "activity")
     @OrderColumn
     @JsonIgnore // TODO: Decide if we want to return perRoles (or IDs) by default
-    val associatedRoles: MutableList<@Valid PerActivityRole> = mutableListOf(),
+    open val associatedRoles: MutableList<@Valid PerActivityRole> = mutableListOf(),
 
     @Column(unique = true)
     @field:Size(min = Constants.Slug.minSize, max = Constants.Slug.maxSize)
-    val slug: String? = null,
+    open val slug: String? = null,
 
     @Id
     @GeneratedValue
-    val id: Long? = null
+    open val id: Long? = null
 )


### PR DESCRIPTION
There was an error when booting Spring because abstract models apparently cannot contain final getters, This PR changes this behaviour

# Review checklist
-   [ ] Properly documents API changes in the corresponding controller test
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
