### PR TITLE
Set Jackson timezone to Lisbon

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,7 @@ server.error.whitelabel.enabled=false
 spring.jackson.default-property-inclusion=non_null
 spring.jackson.deserialization.fail-on-null-creator-properties=true
 spring.jackson.date-format=dd-MM-yyyy
+spring.jackson.time-zone=Europe/Lisbon
 
 # Auth Config
 auth.private-key=classpath:certs/private.pem


### PR DESCRIPTION
This PR changes the default serialization timezone to Lisbon in order to avoid mistakes with daylight saving times.

# Review checklist
-   [ ] Properly documents API changes in the corresponding controller test
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
