### PR TITLE
Refactor/rest like endpoints

### DIFF
--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/AccountController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/AccountController.kt
@@ -29,7 +29,7 @@ class AccountController(private val service: AccountService) {
     @GetMapping("/{id}")
     fun getAccountById(@PathVariable id: Long) = service.getAccountById(id)
 
-    @PostMapping("/new", consumes = ["multipart/form-data"])
+    @PostMapping(consumes = ["multipart/form-data"])
     fun createAccount(
         @RequestPart account: CreateAccountDto,
         @RequestParam
@@ -58,7 +58,7 @@ class AccountController(private val service: AccountService) {
         return emptyMap()
     }
 
-    @PostMapping("/changePassword/{id}")
+    @PostMapping("/{id}/password")
     fun changePassword(@PathVariable id: Long, @RequestBody dto: ChangePasswordDto): Map<String, String> {
         service.changePassword(id, dto)
         return emptyMap()

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/AuthController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/AuthController.kt
@@ -14,7 +14,7 @@ import pt.up.fe.ni.website.backend.service.AuthService
 @RestController
 @RequestMapping("/auth")
 class AuthController(val authService: AuthService) {
-    @PostMapping("/new")
+    @PostMapping
     fun getNewToken(@RequestBody loginDto: LoginDto): Map<String, String> {
         val account = authService.authenticate(loginDto.email, loginDto.password)
         val accessToken = authService.generateAccessToken(account)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/EventController.kt
@@ -21,7 +21,9 @@ import pt.up.fe.ni.website.backend.utils.validation.ValidImage
 @Validated
 class EventController(private val service: EventService) {
     @GetMapping
-    fun getAllEvents() = service.getAllEvents()
+    fun getEvents(@RequestParam(required = false, name = "category") category: String?): List<Event> {
+        return category?.let { service.getEventsByCategory(it) } ?: service.getAllEvents()
+    }
 
     @GetMapping("/{id:\\d+}")
     fun getEventById(@PathVariable id: Long) = service.getEventById(id)
@@ -32,7 +34,7 @@ class EventController(private val service: EventService) {
     @GetMapping("/{eventSlug}**")
     fun getEvent(@PathVariable eventSlug: String) = service.getEventBySlug(eventSlug)
 
-    @PostMapping("/new", consumes = ["multipart/form-data"])
+    @PostMapping(consumes = ["multipart/form-data"])
     fun createEvent(
         @RequestPart event: EventDto,
         @RequestParam
@@ -61,13 +63,13 @@ class EventController(private val service: EventService) {
         return service.updateEventById(id, event)
     }
 
-    @PutMapping("/{idEvent}/addTeamMember/{idAccount}")
+    @PutMapping("/{idEvent}/team/{idAccount}")
     fun addTeamMemberById(
         @PathVariable idEvent: Long,
         @PathVariable idAccount: Long
     ) = service.addTeamMemberById(idEvent, idAccount)
 
-    @PutMapping("/{idEvent}/removeTeamMember/{idAccount}")
+    @DeleteMapping("/{idEvent}/team/{idAccount}")
     fun removeTeamMemberById(
         @PathVariable idEvent: Long,
         @PathVariable idAccount: Long

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/GenerationController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/GenerationController.kt
@@ -16,8 +16,8 @@ import pt.up.fe.ni.website.backend.service.GenerationService
 @RestController
 @RequestMapping("/generations")
 class GenerationController(private val service: GenerationService) {
-    @GetMapping("/years")
-    fun getGenerationsSchoolYears() = service.getGenerationsSchoolYears()
+    @GetMapping
+    fun getAllGenerations() = service.getAllGenerations()
 
     @GetMapping("/{id:\\d+}")
     fun getGenerationById(@PathVariable id: Long) = service.getGenerationById(id)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/GenerationController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/GenerationController.kt
@@ -16,8 +16,8 @@ import pt.up.fe.ni.website.backend.service.GenerationService
 @RestController
 @RequestMapping("/generations")
 class GenerationController(private val service: GenerationService) {
-    @GetMapping
-    fun getAllGenerations() = service.getAllGenerations()
+    @GetMapping("/years")
+    fun getGenerationsSchoolYears() = service.getGenerationsSchoolYears()
 
     @GetMapping("/{id:\\d+}")
     fun getGenerationById(@PathVariable id: Long) = service.getGenerationById(id)
@@ -28,7 +28,7 @@ class GenerationController(private val service: GenerationService) {
     @GetMapping("/latest")
     fun getLatestGeneration() = service.getLatestGeneration()
 
-    @PostMapping("/new")
+    @PostMapping
     fun createNewGeneration(
         @RequestBody dto: GenerationDto
     ) = service.createNewGeneration(dto)

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/PostController.kt
@@ -24,7 +24,7 @@ class PostController(private val service: PostService) {
     @GetMapping("/{postSlug}**")
     fun getPost(@PathVariable postSlug: String) = service.getPostBySlug(postSlug)
 
-    @PostMapping("/new")
+    @PostMapping
     fun createPost(@RequestBody dto: PostDto) = service.createPost(dto)
 
     @PutMapping("/{postId}")

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ProjectController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ProjectController.kt
@@ -30,7 +30,7 @@ class ProjectController(private val service: ProjectService) {
     @GetMapping("/{projectSlug}**")
     fun getProjectBySlug(@PathVariable projectSlug: String) = service.getProjectBySlug(projectSlug)
 
-    @PostMapping("/new", consumes = ["multipart/form-data"])
+    @PostMapping(consumes = ["multipart/form-data"])
     fun createProject(
         @RequestPart project: ProjectDto,
         @RequestParam
@@ -65,13 +65,13 @@ class ProjectController(private val service: ProjectService) {
     @PutMapping("/{id}/unarchive")
     fun unarchiveProjectById(@PathVariable id: Long) = service.unarchiveProjectById(id)
 
-    @PutMapping("/{idProject}/addTeamMember/{idAccount}")
+    @PutMapping("/{idProject}/team/{idAccount}")
     fun addTeamMemberById(
         @PathVariable idProject: Long,
         @PathVariable idAccount: Long
     ) = service.addTeamMemberById(idProject, idAccount)
 
-    @PutMapping("/{idProject}/removeTeamMember/{idAccount}")
+    @DeleteMapping("/{idProject}/team/{idAccount}")
     fun removeTeamMemberById(
         @PathVariable idProject: Long,
         @PathVariable idAccount: Long

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ProjectController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ProjectController.kt
@@ -77,13 +77,13 @@ class ProjectController(private val service: ProjectService) {
         @PathVariable idAccount: Long
     ) = service.removeTeamMemberById(idProject, idAccount)
 
-    @PutMapping("/{idProject}/hallOfFameMember/{idAccount}")
+    @PutMapping("/{idProject}/hallOfFame/{idAccount}")
     fun addHallOfFameMemberById(
         @PathVariable idProject: Long,
         @PathVariable idAccount: Long
     ) = service.addHallOfFameMemberById(idProject, idAccount)
 
-    @DeleteMapping("/{idProject}/hallOfFameMember/{idAccount}")
+    @DeleteMapping("/{idProject}/hallOfFame/{idAccount}")
     fun removeHallOfFameMemberById(
         @PathVariable idProject: Long,
         @PathVariable idAccount: Long

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ProjectController.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/controller/ProjectController.kt
@@ -77,13 +77,13 @@ class ProjectController(private val service: ProjectService) {
         @PathVariable idAccount: Long
     ) = service.removeTeamMemberById(idProject, idAccount)
 
-    @PutMapping("/{idProject}/addHallOfFameMember/{idAccount}")
+    @PutMapping("/{idProject}/hallOfFameMember/{idAccount}")
     fun addHallOfFameMemberById(
         @PathVariable idProject: Long,
         @PathVariable idAccount: Long
     ) = service.addHallOfFameMemberById(idProject, idAccount)
 
-    @PutMapping("/{idProject}/removeHallOfFameMember/{idAccount}")
+    @DeleteMapping("/{idProject}/hallOfFameMember/{idAccount}")
     fun removeHallOfFameMemberById(
         @PathVariable idProject: Long,
         @PathVariable idAccount: Long

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/GenerationService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/GenerationService.kt
@@ -19,7 +19,7 @@ class GenerationService(
     private val activityService: ActivityService
 ) {
 
-    fun getAllGenerations(): List<String> = repository.findAllSchoolYearOrdered()
+    fun getGenerationsSchoolYears(): List<String> = repository.findAllSchoolYearOrdered()
 
     fun getGenerationById(id: Long): GetGenerationDto {
         val generation =

--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/GenerationService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/GenerationService.kt
@@ -19,7 +19,7 @@ class GenerationService(
     private val activityService: ActivityService
 ) {
 
-    fun getGenerationsSchoolYears(): List<String> = repository.findAllSchoolYearOrdered()
+    fun getAllGenerations(): List<String> = repository.findAllSchoolYearOrdered()
 
     fun getGenerationById(id: Long): GetGenerationDto {
         val generation =

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -1,5 +1,6 @@
 package pt.up.fe.ni.website.backend.controller
 
+import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
 import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.util.Calendar
@@ -29,7 +30,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import pt.up.fe.ni.website.backend.config.upload.UploadConfigProperties
 import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
-import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester
@@ -167,7 +167,7 @@ class AccountControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("POST /accounts/new")
+    @DisplayName("POST /accounts")
     inner class CreateAccount {
         private val uuid: UUID = UUID.randomUUID()
         private val mockedSettings = Mockito.mockStatic(UUID::class.java)
@@ -184,7 +184,7 @@ class AccountControllerTest @Autowired constructor(
 
         @Test
         fun `should create the account`() {
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .addPart("account", testAccount.toJson())
                 .perform()
                 .andExpectAll(
@@ -228,7 +228,7 @@ class AccountControllerTest @Autowired constructor(
                 )
             )
 
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .addPart("account", data)
                 .perform()
                 .andExpectAll(
@@ -248,7 +248,7 @@ class AccountControllerTest @Autowired constructor(
         fun `should create the account with valid image`() {
             val expectedPhotoPath = "${uploadConfigProperties.staticServe}/profile/${testAccount.email}-$uuid.jpeg"
 
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .addPart("account", testAccount.toJson())
                 .addFile()
                 .perform()
@@ -276,7 +276,7 @@ class AccountControllerTest @Autowired constructor(
 
         @Test
         fun `should fail to create account with invalid filename extension`() {
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .addPart("account", testAccount.toJson())
                 .addFile(filename = "photo.pdf")
                 .perform()
@@ -292,7 +292,7 @@ class AccountControllerTest @Autowired constructor(
 
         @Test
         fun `should fail to create account with invalid filename media type`() {
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .addPart("account", testAccount.toJson())
                 .addFile(contentType = MediaType.APPLICATION_PDF_VALUE)
                 .perform()
@@ -307,7 +307,7 @@ class AccountControllerTest @Autowired constructor(
 
         @Test
         fun `should fail when missing account part`() {
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .perform()
                 .andExpectAll(
                     status().isBadRequest,
@@ -323,7 +323,7 @@ class AccountControllerTest @Autowired constructor(
         inner class InputValidation {
             private val validationTester = ValidationTester(
                 req = { params: Map<String, Any?> ->
-                    mockMvc.multipartBuilder("/accounts/new")
+                    mockMvc.multipartBuilder("/accounts")
                         .addPart("account", objectMapper.writeValueAsString(params))
                         .perform()
                         .andDocumentErrorResponse(documentation, hasRequestPayload = true)
@@ -463,7 +463,7 @@ class AccountControllerTest @Autowired constructor(
                         )
                         accountPart.headers.contentType = MediaType.APPLICATION_JSON
 
-                        mockMvc.perform(multipart("/accounts/new").part(accountPart))
+                        mockMvc.perform(multipart("/accounts").part(accountPart))
                             .andDocumentErrorResponse(documentation, hasRequestPayload = true)
                     },
                     requiredFields = mapOf(
@@ -538,12 +538,12 @@ class AccountControllerTest @Autowired constructor(
 
         @Test
         fun `should fail to create account with existing email`() {
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .addPart("account", testAccount.toJson())
                 .perform()
                 .andExpect(status().isOk)
 
-            mockMvc.multipartBuilder("/accounts/new")
+            mockMvc.multipartBuilder("/accounts")
                 .addPart("account", testAccount.toJson())
                 .perform()
                 .andExpectAll(
@@ -556,7 +556,7 @@ class AccountControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("POST /accounts/changePassword/{id}")
+    @DisplayName("POST /accounts/{id}/password")
     inner class ChangePassword {
         private val password = "test_password"
         private val changePasswordAccount: Account = ObjectMapper().readValue(
@@ -590,7 +590,7 @@ class AccountControllerTest @Autowired constructor(
         @Test
         fun `should change password`() {
             mockMvc.perform(
-                post("/accounts/changePassword/{id}", changePasswordAccount.id)
+                post("/accounts/{id}/password", changePasswordAccount.id)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         objectMapper.writeValueAsString(
@@ -624,7 +624,7 @@ class AccountControllerTest @Autowired constructor(
         @Test
         fun `should fail due to wrong password`() {
             mockMvc.perform(
-                post("/accounts/changePassword/{id}", changePasswordAccount.id)
+                post("/accounts/{id}/password", changePasswordAccount.id)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         objectMapper.writeValueAsString(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -1,6 +1,5 @@
 package pt.up.fe.ni.website.backend.controller
 
-import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
 import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.util.Calendar
@@ -30,6 +29,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import pt.up.fe.ni.website.backend.config.upload.UploadConfigProperties
 import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
+import pt.up.fe.ni.website.backend.model.constants.AccountConstants as Constants
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.utils.TestUtils
 import pt.up.fe.ni.website.backend.utils.ValidationTester

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AccountControllerTest.kt
@@ -610,7 +610,7 @@ class AccountControllerTest @Autowired constructor(
                     documentRequestPayload = true
                 )
 
-            mockMvc.post("/auth/new") {
+            mockMvc.post("/auth") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(
                     mapOf(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/AuthControllerTest.kt
@@ -63,7 +63,7 @@ class AuthControllerTest @Autowired constructor(
     )
 
     @NestedTest
-    @DisplayName("POST /auth/new")
+    @DisplayName("POST /auth")
     inner class GetNewToken {
         @BeforeEach
         fun setup() {
@@ -75,7 +75,7 @@ class AuthControllerTest @Autowired constructor(
         @Test
         fun `should fail when email is not registered`() {
             mockMvc.perform(
-                post("/auth/new")
+                post("/auth")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         objectMapper.writeValueAsString(
@@ -96,7 +96,7 @@ class AuthControllerTest @Autowired constructor(
         @Test
         fun `should fail when password is incorrect`() {
             mockMvc.perform(
-                post("/auth/new")
+                post("/auth")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(LoginDto(testAccount.email, "wrong_password")))
             )
@@ -110,7 +110,7 @@ class AuthControllerTest @Autowired constructor(
         @Test
         fun `should return access and refresh tokens`() {
             mockMvc.perform(
-                post("/auth/new")
+                post("/auth")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(LoginDto(testAccount.email, testPassword)))
             )
@@ -155,7 +155,7 @@ class AuthControllerTest @Autowired constructor(
 
         @Test
         fun `should return new access token`() {
-            mockMvc.post("/auth/new") {
+            mockMvc.post("/auth") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(LoginDto(testAccount.email, testPassword))
             }.andReturn().response.let { response ->
@@ -216,7 +216,7 @@ class AuthControllerTest @Autowired constructor(
 
         @Test
         fun `should return authenticated user`() {
-            mockMvc.post("/auth/new") {
+            mockMvc.post("/auth") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(LoginDto(testAccount.email, testPassword))
             }.andReturn().response.let { response ->

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,7 +28,6 @@ import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants
 import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
-import org.junit.jupiter.api.Nested
 import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.repository.EventRepository
@@ -149,7 +149,6 @@ internal class EventControllerTest @Autowired constructor(
                 )
             )
             extraEvents.forEach { repository.save(it) }
-
 
             mockMvc.perform(get("/events?category={category}", testEvent.category))
                 .andExpectAll(

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -27,6 +27,7 @@ import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants
 import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
+import org.junit.jupiter.api.Nested
 import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.repository.EventRepository
@@ -80,26 +81,11 @@ internal class EventControllerTest @Autowired constructor(
 
     val documentation = PayloadEvent()
 
-    @NestedTest
-    @DisplayName("GET /events")
-    inner class GetAllEvents {
-        private val testEvents = listOf(
-            testEvent,
-            Event(
-                "Bad event",
-                "This event was a failure",
-                mutableListOf(),
-                mutableListOf(),
-                null,
-                "bad-image.png",
-                null,
-                DateInterval(
-                    TestUtils.createDate(2021, Calendar.OCTOBER, 27),
-                    null
-                ),
-                null,
-                null
-            )
+    @DisplayName("GET events?category={category}")
+    @Nested
+    inner class GetEvents {
+        private val testEvents = mutableListOf(
+            testEvent
         )
 
         @BeforeEach
@@ -123,72 +109,48 @@ internal class EventControllerTest @Autowired constructor(
                     """.trimMargin()
                 )
         }
-    }
-
-    @NestedTest
-    @DisplayName("GET events?category={category}")
-    inner class GetEventsByCategory {
-        private val testEvents = listOf(
-            testEvent,
-            Event(
-                "Bad event",
-                "This event was a failure",
-                mutableListOf(testAccount),
-                mutableListOf(),
-                null,
-                "weird-al.png",
-                null,
-                DateInterval(
-                    TestUtils.createDate(2021, Calendar.OCTOBER, 27),
-                    null
-                ),
-                null,
-                null
-            ),
-            Event(
-                "Mid event",
-                "This event was ok",
-                mutableListOf(),
-                mutableListOf(),
-                null,
-                "waldo.jpeg",
-                null,
-                DateInterval(
-                    TestUtils.createDate(2022, Calendar.JANUARY, 15),
-                    null
-                ),
-                null,
-                "Other category"
-            ),
-            Event(
-                "Cool event",
-                "This event was a awesome",
-                mutableListOf(testAccount),
-                mutableListOf(),
-                null,
-                "ni.png",
-                null,
-                DateInterval(
-                    TestUtils.createDate(2022, Calendar.SEPTEMBER, 11),
-                    null
-                ),
-                null,
-                "Great Events"
-            )
-        )
 
         private val queryParameters = listOf(
             parameterWithName("category").description("Category of the events to retrieve").optional()
         )
 
-        @BeforeEach
-        fun addToRepositories() {
-            accountRepository.save(testAccount)
-            for (event in testEvents) repository.save(event)
-        }
-
         @Test
         fun `should return all events of the category`() {
+            val extraEvents = listOf(
+                Event(
+                    "Mid event",
+                    "This event was ok",
+                    mutableListOf(),
+                    mutableListOf(),
+                    "bloat",
+                    "waldo.jpeg",
+                    null,
+                    DateInterval(
+                        TestUtils.createDate(2022, Calendar.JANUARY, 15),
+                        null
+                    ),
+                    "FCUP",
+                    "Other category"
+                ),
+                Event(
+                    "Cool event",
+                    "This event was a awesome",
+                    mutableListOf(testAccount),
+                    mutableListOf(),
+                    "ni",
+                    "ni.png",
+                    null,
+                    DateInterval(
+                        TestUtils.createDate(2022, Calendar.SEPTEMBER, 11),
+                        null
+                    ),
+                    "NI",
+                    "Great Events"
+                )
+            )
+            extraEvents.forEach { repository.save(it) }
+
+
             mockMvc.perform(get("/events?category={category}", testEvent.category))
                 .andExpectAll(
                     status().isOk,

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -1,5 +1,6 @@
 package pt.up.fe.ni.website.backend.controller
 
+import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
 import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.util.Calendar
@@ -26,7 +27,6 @@ import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants
-import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
 import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.repository.EventRepository
@@ -116,8 +116,9 @@ internal class EventControllerTest @Autowired constructor(
                 .andExpect(content().json(objectMapper.writeValueAsString(testEvents)))
                 .andDocument(
                     documentation.getModelDocumentationArray(),
-                    "Get all the events",
+                    "Get all the events or filter them by category",
                     """The operation returns an array of events, allowing to easily retrieve all the created events.
+                        |It also allows to filter the events by category, using the query parameter "category".
                         |This is useful for example in the frontend's event page, where events are displayed.
                     """.trimMargin()
                 )

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/EventControllerTest.kt
@@ -1,6 +1,5 @@
 package pt.up.fe.ni.website.backend.controller
 
-import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
 import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.util.Calendar
@@ -27,6 +26,7 @@ import pt.up.fe.ni.website.backend.model.Account
 import pt.up.fe.ni.website.backend.model.CustomWebsite
 import pt.up.fe.ni.website.backend.model.Event
 import pt.up.fe.ni.website.backend.model.constants.ActivityConstants
+import pt.up.fe.ni.website.backend.model.constants.EventConstants as Constants
 import pt.up.fe.ni.website.backend.model.embeddable.DateInterval
 import pt.up.fe.ni.website.backend.repository.AccountRepository
 import pt.up.fe.ni.website.backend.repository.EventRepository
@@ -143,7 +143,7 @@ internal class EventControllerTest @Autowired constructor(
                     null
                 ),
                 null,
-                null,
+                null
             ),
             Event(
                 "Mid event",
@@ -158,7 +158,7 @@ internal class EventControllerTest @Autowired constructor(
                     null
                 ),
                 null,
-                "Other category",
+                "Other category"
             ),
             Event(
                 "Cool event",
@@ -173,7 +173,7 @@ internal class EventControllerTest @Autowired constructor(
                     null
                 ),
                 null,
-                "Great Events",
+                "Great Events"
             )
         )
 

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/GenerationControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/GenerationControllerTest.kt
@@ -93,7 +93,7 @@ class GenerationControllerTest @Autowired constructor(
     )
 
     @NestedTest
-    @DisplayName("GET /generations")
+    @DisplayName("GET /generations/years")
     inner class GetAllGenerations {
 
         @BeforeEach
@@ -105,7 +105,7 @@ class GenerationControllerTest @Autowired constructor(
 
         @Test
         fun `should return all generation years`() {
-            mockMvc.perform(get("/generations"))
+            mockMvc.perform(get("/generations/years"))
                 .andExpectAll(
                     status().isOk,
                     content().contentType(MediaType.APPLICATION_JSON),
@@ -124,7 +124,7 @@ class GenerationControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("GET /generations/year")
+    @DisplayName("GET /generations/{year}")
     inner class GetGenerationByYear {
         @BeforeEach
         fun addGenerations() {
@@ -393,12 +393,12 @@ class GenerationControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("POST /generations/new")
+    @DisplayName("POST /generations")
     inner class CreateGeneration {
         @Test
         fun `should create a new generation`() {
             mockMvc.perform(
-                post("/generations/new").contentType(MediaType.APPLICATION_JSON).content(
+                post("/generations").contentType(MediaType.APPLICATION_JSON).content(
                     objectMapper.writeValueAsString(GenerationDto("22-23", emptyList()))
                 )
             )
@@ -438,7 +438,7 @@ class GenerationControllerTest @Autowired constructor(
             )
 
             mockMvc.perform(
-                post("/generations/new")
+                post("/generations")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(generationDtoWithRoles))
             )
@@ -484,7 +484,7 @@ class GenerationControllerTest @Autowired constructor(
             )
 
             mockMvc.perform(
-                post("/generations/new")
+                post("/generations")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(generationDtoWithRoles))
             )
@@ -511,7 +511,7 @@ class GenerationControllerTest @Autowired constructor(
         @Test
         fun `should fail if year is not specified and there are no generations`() {
             mockMvc.perform(
-                post("/generations/new")
+                post("/generations")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(GenerationDto(null, emptyList())))
             )
@@ -536,7 +536,7 @@ class GenerationControllerTest @Autowired constructor(
             @Test
             fun `should infer the year if not specified and create generation`() {
                 mockMvc.perform(
-                    post("/generations/new")
+                    post("/generations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(GenerationDto(null, emptyList())))
                 )
@@ -564,7 +564,7 @@ class GenerationControllerTest @Autowired constructor(
                 )
 
                 mockMvc.perform(
-                    post("/generations/new")
+                    post("/generations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(generationDtoWithAccounts))
                 )
@@ -615,7 +615,7 @@ class GenerationControllerTest @Autowired constructor(
                 )
 
                 mockMvc.perform(
-                    post("/generations/new")
+                    post("/generations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(generationDtoWithActivities))
                 )
@@ -669,7 +669,7 @@ class GenerationControllerTest @Autowired constructor(
             @Test
             fun `should fail if the year already exists`() {
                 mockMvc.perform(
-                    post("/generations/new")
+                    post("/generations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(
                             objectMapper.writeValueAsString(GenerationDto("22-23", emptyList()))
@@ -686,7 +686,7 @@ class GenerationControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("PATCH /generations/year")
+    @DisplayName("PATCH /generations/{year}")
     inner class UpdateGenerationByYear {
         @BeforeEach
         fun addGenerations() {

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/GenerationControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/GenerationControllerTest.kt
@@ -93,7 +93,7 @@ class GenerationControllerTest @Autowired constructor(
     )
 
     @NestedTest
-    @DisplayName("GET /generations/years")
+    @DisplayName("GET /generations")
     inner class GetAllGenerations {
 
         @BeforeEach
@@ -105,7 +105,7 @@ class GenerationControllerTest @Autowired constructor(
 
         @Test
         fun `should return all generation years`() {
-            mockMvc.perform(get("/generations/years"))
+            mockMvc.perform(get("/generations"))
                 .andExpectAll(
                     status().isOk,
                     content().contentType(MediaType.APPLICATION_JSON),

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/PostControllerTest.kt
@@ -187,7 +187,7 @@ internal class PostControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("POST /posts/new")
+    @DisplayName("POST /posts")
     inner class CreatePost {
         @BeforeEach
         fun clearPosts() {
@@ -197,7 +197,7 @@ internal class PostControllerTest @Autowired constructor(
         @Test
         fun `should create a new post`() {
             mockMvc.perform(
-                post("/posts/new")
+                post("/posts")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(testPost))
             )
@@ -221,13 +221,13 @@ internal class PostControllerTest @Autowired constructor(
 
         @Test
         fun `should fail to create post with existing slug`() {
-            mockMvc.post("/posts/new") {
+            mockMvc.post("/posts") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(testPost)
             }.andExpect { status { isOk() } }
 
             mockMvc.perform(
-                post("/posts/new")
+                post("/posts")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(testPost))
             )
@@ -246,7 +246,7 @@ internal class PostControllerTest @Autowired constructor(
             private val validationTester = ValidationTester(
                 req = { params: Map<String, Any?> ->
                     mockMvc.perform(
-                        post("/posts/new")
+                        post("/posts")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(params))
                     )

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -1423,7 +1423,7 @@ internal class ProjectControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("PUT /projects/{idProject}/hallOfFameMember/{idAccount}")
+    @DisplayName("PUT /projects/{idProject}/hallOfFame/{idAccount}")
     inner class AddHallOfFameMember {
         private val newAccount = Account(
             "Another test Account",
@@ -1457,7 +1457,7 @@ internal class ProjectControllerTest @Autowired constructor(
         @Test
         fun `should add account to project's hall of fame`() {
             mockMvc.perform(
-                put("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, newAccount.id)
+                put("/projects/{idProject}/hallOfFame/{idAccount}", testProject.id, newAccount.id)
             )
                 .andExpectAll(
                     status().isOk, content().contentType(MediaType.APPLICATION_JSON),
@@ -1491,7 +1491,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail if the account does not exist`() {
-            mockMvc.perform(put("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, 1234))
+            mockMvc.perform(put("/projects/{idProject}/hallOfFame/{idAccount}", testProject.id, 1234))
                 .andExpectAll(
                     status().isNotFound,
                     content().contentType(MediaType.APPLICATION_JSON),
@@ -1506,7 +1506,7 @@ internal class ProjectControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("DELETE /projects/{idProject}/hallOfFameMember/{idAccount}")
+    @DisplayName("DELETE /projects/{idProject}/hallOfFame/{idAccount}")
     inner class RemoveHallOfFameMember {
         @BeforeEach
         fun addToRepositories() {
@@ -1525,7 +1525,7 @@ internal class ProjectControllerTest @Autowired constructor(
         @Test
         fun `should remove an account from project's hall of fame`() {
             mockMvc.perform(
-                delete("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, testAccount2.id)
+                delete("/projects/{idProject}/hallOfFame/{idAccount}", testProject.id, testAccount2.id)
             )
                 .andExpectAll(
                     status().isOk,
@@ -1542,7 +1542,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail if the account does not exist`() {
-            mockMvc.perform(delete("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, 1234))
+            mockMvc.perform(delete("/projects/{idProject}/hallOfFame/{idAccount}", testProject.id, 1234))
                 .andExpectAll(
                     status().isNotFound,
                     content().contentType(MediaType.APPLICATION_JSON),

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -274,7 +274,7 @@ internal class ProjectControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("POST /projects/new")
+    @DisplayName("POST /projects")
     inner class CreateProject {
         private val uuid: UUID = UUID.randomUUID()
         private val mockedSettings = Mockito.mockStatic(UUID::class.java)
@@ -315,7 +315,7 @@ internal class ProjectControllerTest @Autowired constructor(
                 )
             )
 
-            mockMvc.multipartBuilder("/projects/new")
+            mockMvc.multipartBuilder("/projects")
                 .addPart("project", projectPart)
                 .addFile(name = "image")
                 .perform()
@@ -368,13 +368,13 @@ internal class ProjectControllerTest @Autowired constructor(
                 mutableListOf(testAccount)
             )
 
-            mockMvc.multipartBuilder("/projects/new")
+            mockMvc.multipartBuilder("/projects")
                 .addPart("project", objectMapper.writeValueAsString(testProject))
                 .addFile(name = "image")
                 .perform()
                 .andExpect { status().isOk }
 
-            mockMvc.multipartBuilder("/projects/new")
+            mockMvc.multipartBuilder("/projects")
                 .addPart("project", objectMapper.writeValueAsString(duplicatedSlugProject))
                 .addFile(name = "image")
                 .perform()
@@ -389,7 +389,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail to create project with invalid filename extension`() {
-            mockMvc.multipartBuilder("/projects/new")
+            mockMvc.multipartBuilder("/projects")
                 .addPart("project", objectMapper.writeValueAsString(testProject))
                 .addFile(name = "image", filename = "image.pdf")
                 .perform()
@@ -405,7 +405,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail to create project with invalid filename media type`() {
-            mockMvc.multipartBuilder("/projects/new")
+            mockMvc.multipartBuilder("/projects")
                 .addPart("project", objectMapper.writeValueAsString(testProject))
                 .addFile(name = "image", contentType = MediaType.APPLICATION_PDF_VALUE)
                 .perform()
@@ -421,7 +421,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail when missing project part`() {
-            mockMvc.multipartBuilder("/projects/new")
+            mockMvc.multipartBuilder("/projects")
                 .addFile(name = "image")
                 .perform()
                 .andExpectAll(
@@ -438,7 +438,7 @@ internal class ProjectControllerTest @Autowired constructor(
         inner class InputValidation {
             private val validationTester = ValidationTester(
                 req = { params: Map<String, Any?> ->
-                    mockMvc.multipartBuilder("/projects/new")
+                    mockMvc.multipartBuilder("/projects")
                         .addPart("project", objectMapper.writeValueAsString(params))
                         .addFile(name = "image")
                         .perform()
@@ -1289,7 +1289,7 @@ internal class ProjectControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("PUT /projects/{projectId}/addTeamMember/{accountId}")
+    @DisplayName("PUT /projects/{projectId}/team/{accountId}")
     inner class AddTeamMember {
 
         private val newAccount = Account(
@@ -1324,7 +1324,7 @@ internal class ProjectControllerTest @Autowired constructor(
         @Test
         fun `should add a team member`() {
             mockMvc.perform(
-                put("/projects/{projectId}/addTeamMember/{accountId}", testProject.id, newAccount.id)
+                put("/projects/{projectId}/team/{accountId}", testProject.id, newAccount.id)
             )
                 .andExpectAll(
                     status().isOk, content().contentType(MediaType.APPLICATION_JSON),
@@ -1358,7 +1358,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail if the team member does not exist`() {
-            mockMvc.perform(put("/projects/{projectId}/addTeamMember/{accountId}", testProject.id, 1234))
+            mockMvc.perform(put("/projects/{projectId}/team/{accountId}", testProject.id, 1234))
                 .andExpectAll(
                     status().isNotFound,
                     content().contentType(MediaType.APPLICATION_JSON),
@@ -1373,7 +1373,7 @@ internal class ProjectControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("PUT /projects/{projectId}/removeTeamMember/{accountId}")
+    @DisplayName("DELETE /projects/{projectId}/team/{accountId}")
     inner class RemoveTeamMember {
 
         @BeforeEach
@@ -1392,7 +1392,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should remove a team member`() {
-            mockMvc.perform(put("/projects/{projectId}/removeTeamMember/{accountId}", testProject.id, testAccount.id))
+            mockMvc.perform(delete("/projects/{projectId}/team/{accountId}", testProject.id, testAccount.id))
                 .andExpectAll(
                     status().isOk,
                     content().contentType(MediaType.APPLICATION_JSON),
@@ -1408,7 +1408,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail if the team member does not exist`() {
-            mockMvc.perform(put("/projects/{projectId}/removeTeamMember/{accountId}", testProject.id, 1234))
+            mockMvc.perform(delete("/projects/{projectId}/team/{accountId}", testProject.id, 1234))
                 .andExpectAll(
                     status().isNotFound,
                     content().contentType(MediaType.APPLICATION_JSON),

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/controller/ProjectControllerTest.kt
@@ -1423,7 +1423,7 @@ internal class ProjectControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("PUT /projects/{idProject}/addHallOfFameMember/{idAccount}")
+    @DisplayName("PUT /projects/{idProject}/hallOfFameMember/{idAccount}")
     inner class AddHallOfFameMember {
         private val newAccount = Account(
             "Another test Account",
@@ -1457,7 +1457,7 @@ internal class ProjectControllerTest @Autowired constructor(
         @Test
         fun `should add account to project's hall of fame`() {
             mockMvc.perform(
-                put("/projects/{idProject}/addHallOfFameMember/{idAccount}", testProject.id, newAccount.id)
+                put("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, newAccount.id)
             )
                 .andExpectAll(
                     status().isOk, content().contentType(MediaType.APPLICATION_JSON),
@@ -1491,7 +1491,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail if the account does not exist`() {
-            mockMvc.perform(put("/projects/{idProject}/addHallOfFameMember/{idAccount}", testProject.id, 1234))
+            mockMvc.perform(put("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, 1234))
                 .andExpectAll(
                     status().isNotFound,
                     content().contentType(MediaType.APPLICATION_JSON),
@@ -1506,7 +1506,7 @@ internal class ProjectControllerTest @Autowired constructor(
     }
 
     @NestedTest
-    @DisplayName("PUT /projects/{idProject}/removeHallOfFameMember/{idAccount}")
+    @DisplayName("DELETE /projects/{idProject}/hallOfFameMember/{idAccount}")
     inner class RemoveHallOfFameMember {
         @BeforeEach
         fun addToRepositories() {
@@ -1525,7 +1525,7 @@ internal class ProjectControllerTest @Autowired constructor(
         @Test
         fun `should remove an account from project's hall of fame`() {
             mockMvc.perform(
-                put("/projects/{idProject}/removeHallOfFameMember/{idAccount}", testProject.id, testAccount2.id)
+                delete("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, testAccount2.id)
             )
                 .andExpectAll(
                     status().isOk,
@@ -1542,7 +1542,7 @@ internal class ProjectControllerTest @Autowired constructor(
 
         @Test
         fun `should fail if the account does not exist`() {
-            mockMvc.perform(put("/projects/{idProject}/removeHallOfFameMember/{idAccount}", testProject.id, 1234))
+            mockMvc.perform(delete("/projects/{idProject}/hallOfFameMember/{idAccount}", testProject.id, 1234))
                 .andExpectAll(
                     status().isNotFound,
                     content().contentType(MediaType.APPLICATION_JSON),

--- a/src/test/kotlin/pt/up/fe/ni/website/backend/utils/documentation/utils/MockMVCExtension.kt
+++ b/src/test/kotlin/pt/up/fe/ni/website/backend/utils/documentation/utils/MockMVCExtension.kt
@@ -23,6 +23,7 @@ class MockMVCExtension {
             requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
             responseHeaders: List<HeaderDescriptorWithType> = emptyList(),
             urlParameters: List<ParameterDescriptorWithType> = emptyList(),
+            queryParameters: List<ParameterDescriptorWithType> = emptyList(),
             documentRequestPayload: Boolean = false,
             hasRequestPayload: Boolean = false
         ): ResultActions {
@@ -31,6 +32,7 @@ class MockMVCExtension {
                 summary,
                 description,
                 urlParameters,
+                queryParameters,
                 documentation.payload.Request().schema(),
                 documentation.payload.Request().getSchemaFieldDescriptors(),
                 requestHeaders,
@@ -50,6 +52,7 @@ class MockMVCExtension {
             requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
             responseHeaders: List<HeaderDescriptorWithType> = emptyList(),
             urlParameters: List<ParameterDescriptorWithType> = emptyList(),
+            queryParameters: List<ParameterDescriptorWithType> = emptyList(),
             documentRequestPayload: Boolean = false,
             hasRequestPayload: Boolean = false
         ): ResultActions {
@@ -58,6 +61,7 @@ class MockMVCExtension {
                 summary,
                 description,
                 urlParameters,
+                queryParameters,
                 requestPayload.Request().schema(),
                 requestPayload.Request().getSchemaFieldDescriptors(),
                 requestHeaders,
@@ -75,6 +79,7 @@ class MockMVCExtension {
             description: String? = null,
             requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
             urlParameters: List<ParameterDescriptorWithType> = emptyList(),
+            queryParameters: List<ParameterDescriptorWithType> = emptyList(),
             documentRequestPayload: Boolean = false,
             hasRequestPayload: Boolean = false
         ): ResultActions {
@@ -83,6 +88,7 @@ class MockMVCExtension {
                 summary,
                 description,
                 urlParameters,
+                queryParameters,
                 documentation.payload.Request().schema(),
                 documentation.payload.Request().getSchemaFieldDescriptors(),
                 requestHeaders,
@@ -101,6 +107,7 @@ class MockMVCExtension {
             description: String? = null,
             requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
             urlParameters: List<ParameterDescriptorWithType> = emptyList(),
+            queryParameters: List<ParameterDescriptorWithType> = emptyList(),
             documentRequestPayload: Boolean = false,
             hasRequestPayload: Boolean = false
         ): ResultActions {
@@ -109,6 +116,7 @@ class MockMVCExtension {
                 summary,
                 description,
                 urlParameters,
+                queryParameters,
                 requestPayload.Request().schema(),
                 requestPayload.Request().getSchemaFieldDescriptors(),
                 requestHeaders,
@@ -126,6 +134,7 @@ class MockMVCExtension {
             description: String? = null,
             requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
             urlParameters: List<ParameterDescriptorWithType> = emptyList(),
+            queryParameters: List<ParameterDescriptorWithType> = emptyList(),
             documentRequestPayload: Boolean = false,
             hasRequestPayload: Boolean = false
         ): ResultActions {
@@ -134,6 +143,7 @@ class MockMVCExtension {
                 summary,
                 description,
                 urlParameters,
+                queryParameters,
                 documentation.payload.Request().schema(),
                 documentation.payload.Request().getSchemaFieldDescriptors(),
                 requestHeaders,
@@ -152,6 +162,7 @@ class MockMVCExtension {
             description: String? = null,
             requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
             urlParameters: List<ParameterDescriptorWithType> = emptyList(),
+            queryParameters: List<ParameterDescriptorWithType> = emptyList(),
             documentRequestPayload: Boolean = false,
             hasRequestPayload: Boolean = false
         ): ResultActions {
@@ -160,6 +171,7 @@ class MockMVCExtension {
                 summary,
                 description,
                 urlParameters,
+                queryParameters,
                 requestPayload.Request().schema(),
                 requestPayload.Request().getSchemaFieldDescriptors(),
                 requestHeaders,
@@ -176,6 +188,7 @@ class MockMVCExtension {
             summary: String?,
             description: String?,
             urlParameters: List<ParameterDescriptorWithType>,
+            queryParameters: List<ParameterDescriptorWithType>,
             requestSchema: Schema,
             requestFields: List<FieldDescriptor>,
             requestHeaders: List<HeaderDescriptorWithType>,
@@ -202,7 +215,7 @@ class MockMVCExtension {
                 builder.requestFields(requestFields)
             }
 
-            builder.requestHeaders(requestHeaders).pathParameters(urlParameters)
+            builder.requestHeaders(requestHeaders).pathParameters(urlParameters).queryParameters(queryParameters)
 
             builder.responseSchema(responseSchema).responseFields(responseFields).responseHeaders(responseHeaders)
 


### PR DESCRIPTION
Closes #143 

First of all kudos to @BrunoRosendo for the great groundwork.
This PR refactors some of the endpoints being used and adds support for URL queries in the documentation, as, as of now, some endpoints rely on URL queries to filter the returned contents:


Next is a list of the affected endpoints:
- accounts
    - POST /changePassord/{id} -> POST /{id}/password
    - POST /new -> POST

- auth
    - POST /new -> POST

- events
    - GET /category -> GET ?category=Great Events (Missing documentation for query parameters)
    - POST /new -> POST
    - PUT /{idEvent}/addTeamMember/{idAccount} -> PUT /{idEvent}/team/{idAccount}
    - PUT /{idEvent}/removeTeamMember/{idAccount} -> DELETE /{idEvent}/team/{idAccount}

- generations
    - GET -> GET /years
    - POST /new -> POST

- posts
    - POST new -> POST

- projects
    - POST /new -> POST
    - PUT /{idProject}/addTeamMember/{idAccount} -> PUT /{idProject}/team/{idAccount}
    - PUT /{idProject}/removeTeamMember/{idAccount} -> DELETE /{idProject}/team/{idAccount}
    - PUT /{idEvent}/addHallOffFameMember/{idAccount} -> PUT /{idEvent}/hallOfFameMember/{idAccount}
    - PUT /{idEvent}/removeHallOfFameMember/{idAccount} -> DELETE /{idEvent}/hallOfFameMember/{idAccount}

# Review checklist
-   [x] Properly documents API changes in the corresponding controller test
-   [x] Contains enough appropriate tests
-   [x] Behavior is as expected
-   [x] Clean, well structured code
