### PR TITLE
Fixed unchanged email account updates

### DIFF
--- a/src/main/kotlin/pt/up/fe/ni/website/backend/service/AccountService.kt
+++ b/src/main/kotlin/pt/up/fe/ni/website/backend/service/AccountService.kt
@@ -48,8 +48,10 @@ class AccountService(
     fun updateAccountById(id: Long, dto: UpdateAccountDto): Account {
         val account = getAccountById(id)
 
-        repository.findByEmail(dto.email)?.let {
-            throw IllegalArgumentException(ErrorMessages.emailAlreadyExists)
+        if (account.email != dto.email) {
+            repository.findByEmail(dto.email)?.let {
+                throw IllegalArgumentException(ErrorMessages.emailAlreadyExists)
+            }
         }
 
         dto.photoFile?.let {


### PR DESCRIPTION
Closes #176 

Checks if the email was changed before comparing with already used emails. Adds a test case to verify this instance.

# Review checklist
-   [ ] Properly documents API changes in the corresponding controller test
-   [ ] Contains enough appropriate tests
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
